### PR TITLE
PR 4: Contact health check page

### DIFF
--- a/app/components/common/receipt-selector.tsx
+++ b/app/components/common/receipt-selector.tsx
@@ -219,6 +219,7 @@ function ReceiptGallery({
       setOpen={setOpen}
       title="Attach Files"
       description="Select the receipts to attach. Files already attached elsewhere can't be reused."
+      size="xl"
     >
       <div className="relative">
         <IconSearch className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />

--- a/app/components/modals/confirm-destructive-modal.tsx
+++ b/app/components/modals/confirm-destructive-modal.tsx
@@ -1,12 +1,32 @@
 import { IconAlertTriangleFilled } from "@tabler/icons-react";
-import { useEffect, useState } from "react";
+import { JSX, useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 
 import { Button } from "~/components/ui/button";
 import { DrawerDialog, DrawerDialogFooter } from "~/components/ui/drawer-dialog";
 import { SubmitButton } from "~/components/ui/submit-button";
 
-export function ConfirmDestructiveModal({ description }: { description: string }) {
+type Props = {
+  description: string;
+  triggerLabel?: string;
+  triggerIcon?: JSX.Element;
+  confirmLabel?: string;
+  method?: "post" | "delete";
+  /** Value submitted as `_action`. */
+  actionValue?: string;
+  /** Extra hidden fields submitted with the confirmation. */
+  fields?: Record<string, string>;
+};
+
+export function ConfirmDestructiveModal({
+  description,
+  triggerLabel = "Delete",
+  triggerIcon,
+  confirmLabel = "Confirm",
+  method = "delete",
+  actionValue = "delete",
+  fields,
+}: Props) {
   const [open, setOpen] = useState(false);
   const fetcher = useFetcher();
   const isSubmitting = fetcher.state !== "idle";
@@ -21,13 +41,12 @@ export function ConfirmDestructiveModal({ description }: { description: string }
     <>
       <Button
         variant="outline"
-        type="submit"
-        name="_action"
-        value="delete"
+        type="button"
         className="hover:border-destructive hover:bg-destructive hover:text-destructive-foreground w-min"
         onClick={() => setOpen(true)}
       >
-        Delete
+        {triggerIcon}
+        {triggerLabel}
       </Button>
       <DrawerDialog
         open={open}
@@ -37,18 +56,21 @@ export function ConfirmDestructiveModal({ description }: { description: string }
         icon={<IconAlertTriangleFilled className="text-destructive size-8" />}
       >
         <DrawerDialogFooter className="gap-2 sm:space-x-0">
-          <Button variant="outline" type="submit" onClick={() => setOpen(false)} disabled={isSubmitting}>
+          <Button variant="outline" type="button" onClick={() => setOpen(false)} disabled={isSubmitting}>
             Cancel
           </Button>
-          <fetcher.Form method="delete">
+          <fetcher.Form method={method}>
+            {Object.entries(fields ?? {}).map(([name, value]) => (
+              <input key={name} type="hidden" name={name} value={value} />
+            ))}
             <SubmitButton
               className="w-full sm:w-auto"
               variant="destructive"
               name="_action"
-              value="delete"
+              value={actionValue}
               isSubmitting={isSubmitting}
             >
-              Confirm
+              {confirmLabel}
             </SubmitButton>
           </fetcher.Form>
         </DrawerDialogFooter>

--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -1,5 +1,6 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { IconX } from "@tabler/icons-react";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "~/lib/utils";
@@ -29,30 +30,43 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "bg-card fixed top-[50%] left-[50%] z-50 grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-300 sm:rounded-lg md:w-full",
-        "data-[state=open]:animate-in data-[state=open]:fade-in-0",
-        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-        <IconX className="size-5" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
+const dialogContentVariants = cva(
+  cn(
+    "bg-card fixed top-[50%] left-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-300 sm:rounded-lg md:w-full",
+    "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+    "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+  ),
+  {
+    variants: {
+      size: {
+        md: "max-w-md",
+        lg: "max-w-2xl",
+        xl: "max-w-4xl",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  },
+);
+
+type DialogContentProps = React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> &
+  VariantProps<typeof dialogContentVariants>;
+
+const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, DialogContentProps>(
+  ({ className, children, size, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content ref={ref} className={cn(dialogContentVariants({ size }), className)} {...props}>
+        {children}
+        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+          <IconX className="size-5" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  ),
+);
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
@@ -89,6 +103,7 @@ export {
   Dialog,
   DialogClose,
   DialogContent,
+  dialogContentVariants,
   DialogDescription,
   DialogFooter,
   DialogHeader,

--- a/app/components/ui/drawer-dialog.tsx
+++ b/app/components/ui/drawer-dialog.tsx
@@ -1,9 +1,11 @@
+import { type VariantProps } from "class-variance-authority";
 import { JSX, ReactNode } from "react";
 import { useMediaQuery } from "usehooks-ts";
 
 import {
   Dialog,
   DialogContent,
+  dialogContentVariants,
   DialogDescription,
   DialogFooter,
   DialogHeader,
@@ -26,6 +28,8 @@ type Props = {
   children: ReactNode;
   icon?: JSX.Element;
   description?: string;
+  /** Desktop only — the drawer is always full width. */
+  size?: VariantProps<typeof dialogContentVariants>["size"];
 };
 
 export function DrawerDialog(props: Props) {
@@ -34,7 +38,7 @@ export function DrawerDialog(props: Props) {
   if (isDesktop) {
     return (
       <Dialog open={props.open} onOpenChange={props.setOpen}>
-        <DialogContent>
+        <DialogContent size={props.size}>
           <DialogHeader>
             {props.icon ? <div className="mb-4 size-8 self-center">{props.icon}</div> : null}
             <DialogTitle>{props.title}</DialogTitle>

--- a/app/lib/contact-health.test.ts
+++ b/app/lib/contact-health.test.ts
@@ -1,0 +1,236 @@
+import { ContactType } from "~/lib/constants";
+import {
+  canBeDeleted,
+  displayName,
+  findEmailCrossDuplicates,
+  findNameDuplicates,
+  type HealthContact,
+  isMergeablePair,
+  isMissingRequiredEmail,
+  mergeDescription,
+  type PairedContact,
+  pairKey,
+} from "~/lib/contact-health";
+
+function buildContact(overrides: Partial<HealthContact> & { id: string }): HealthContact {
+  return {
+    firstName: "Riley",
+    lastName: "Chen",
+    organizationName: null,
+    email: null,
+    alternateEmail: null,
+    phone: null,
+    typeId: ContactType.Donor,
+    type: { name: "Donor" },
+    user: null,
+    ...overrides,
+  };
+}
+
+function buildPaired(overrides: Partial<PairedContact> & { id: string }): PairedContact {
+  return {
+    ...buildContact(overrides),
+    _count: { transactions: 0, engagements: 0, accountSubscriptions: 0, assignedUsers: 0 },
+    ...overrides,
+  };
+}
+
+/** Pairs are unordered, so compare them as sorted id sets. */
+function pairIds(pairs: Array<[HealthContact, HealthContact]>) {
+  return pairs.map(([a, b]) => [a.id, b.id].sort().join("|")).sort();
+}
+
+describe("displayName", () => {
+  it("falls back to the organization name when there is no personal name", () => {
+    expect(
+      displayName(buildContact({ id: "a", firstName: null, lastName: null, organizationName: "Acme Foundation" })),
+    ).toBe("Acme Foundation");
+  });
+
+  it("prefers the personal name and tolerates a missing half", () => {
+    expect(displayName(buildContact({ id: "a", lastName: null }))).toBe("Riley");
+    expect(displayName(buildContact({ id: "a", firstName: "  Riley  ", lastName: " Chen " }))).toBe("Riley Chen");
+  });
+
+  it("is empty when the contact has no name at all", () => {
+    expect(displayName(buildContact({ id: "a", firstName: null, lastName: null }))).toBe("");
+  });
+});
+
+describe("findNameDuplicates", () => {
+  it("matches regardless of case and surrounding whitespace", () => {
+    const pairs = findNameDuplicates([
+      buildContact({ id: "a" }),
+      buildContact({ id: "b", firstName: "riley", lastName: " CHEN " }),
+    ]);
+
+    expect(pairIds(pairs)).toEqual(["a|b"]);
+  });
+
+  it("pairs organizations by their organization name", () => {
+    const pairs = findNameDuplicates([
+      buildContact({ id: "a", firstName: null, lastName: null, organizationName: "Acme Foundation" }),
+      buildContact({ id: "b", firstName: null, lastName: null, organizationName: "acme foundation" }),
+      buildContact({ id: "c", firstName: null, lastName: null, organizationName: "Other Org" }),
+    ]);
+
+    expect(pairIds(pairs)).toEqual(["a|b"]);
+  });
+
+  it("emits every combination within a group larger than two", () => {
+    const pairs = findNameDuplicates([buildContact({ id: "a" }), buildContact({ id: "b" }), buildContact({ id: "c" })]);
+
+    expect(pairIds(pairs)).toEqual(["a|b", "a|c", "b|c"]);
+  });
+
+  it("ignores contacts with no name rather than grouping them together", () => {
+    const pairs = findNameDuplicates([
+      buildContact({ id: "a", firstName: null, lastName: null }),
+      buildContact({ id: "b", firstName: null, lastName: null }),
+    ]);
+
+    expect(pairs).toEqual([]);
+  });
+});
+
+describe("findEmailCrossDuplicates", () => {
+  it("matches one contact's alternate email against another's primary", () => {
+    const pairs = findEmailCrossDuplicates([
+      buildContact({ id: "a", email: "riley@work.com", alternateEmail: "riley@home.com" }),
+      buildContact({ id: "b", email: "riley@home.com" }),
+    ]);
+
+    expect(pairIds(pairs)).toEqual(["a|b"]);
+  });
+
+  it("reports a mutual match only once", () => {
+    const pairs = findEmailCrossDuplicates([
+      buildContact({ id: "a", email: "one@x.com", alternateEmail: "two@x.com" }),
+      buildContact({ id: "b", email: "two@x.com", alternateEmail: "one@x.com" }),
+    ]);
+
+    expect(pairIds(pairs)).toEqual(["a|b"]);
+  });
+
+  it("does not pair a contact whose own alternate email matches its own primary", () => {
+    const pairs = findEmailCrossDuplicates([
+      buildContact({ id: "a", email: "same@x.com", alternateEmail: "same@x.com" }),
+    ]);
+
+    expect(pairs).toEqual([]);
+  });
+});
+
+describe("pairKey", () => {
+  it("is the same whichever way round the pair is given", () => {
+    const a = buildContact({ id: "zeta" });
+    const b = buildContact({ id: "alpha" });
+
+    expect(pairKey(a, b)).toBe(pairKey(b, a));
+    expect(pairKey(a, b)).toBe("alpha-zeta");
+  });
+
+  it("distinguishes different pairs sharing a contact", () => {
+    expect(pairKey({ id: "a" }, { id: "b" })).not.toBe(pairKey({ id: "a" }, { id: "c" }));
+  });
+});
+
+describe("merge safety", () => {
+  const plain = buildContact({ id: "plain" });
+  const backsLogin = buildContact({ id: "staff", user: { id: "user1" } });
+
+  it("refuses to delete a contact that backs a user account", () => {
+    // Contact.delete cascades to User, so this is the rule that stops a merge deleting a login.
+    expect(canBeDeleted(plain)).toBe(true);
+    expect(canBeDeleted(backsLogin)).toBe(false);
+  });
+
+  it("keeps a pair where only one side backs a login, since one direction is still legal", () => {
+    expect(isMergeablePair([plain, backsLogin])).toBe(true);
+    expect(isMergeablePair([backsLogin, plain])).toBe(true);
+  });
+
+  it("drops a pair where both sides back a login", () => {
+    expect(isMergeablePair([backsLogin, buildContact({ id: "staff2", user: { id: "user2" } })])).toBe(false);
+  });
+});
+
+describe("isMissingRequiredEmail", () => {
+  it("flags donors with no email", () => {
+    expect(isMissingRequiredEmail({ email: null, typeId: ContactType.Donor })).toBe(true);
+    expect(isMissingRequiredEmail({ email: null, typeId: ContactType.Donor_and_Missionary })).toBe(true);
+  });
+
+  it("ignores types that have no reason to carry an email", () => {
+    expect(isMissingRequiredEmail({ email: null, typeId: ContactType.Staff })).toBe(false);
+    expect(isMissingRequiredEmail({ email: null, typeId: ContactType.Organization })).toBe(false);
+    expect(isMissingRequiredEmail({ email: null, typeId: ContactType.External })).toBe(false);
+  });
+
+  it("ignores donors that already have an email", () => {
+    expect(isMissingRequiredEmail({ email: "riley@x.com", typeId: ContactType.Donor })).toBe(false);
+  });
+});
+
+describe("mergeDescription", () => {
+  it("names the side being deleted and lists what moves", () => {
+    const remove = buildPaired({
+      id: "b",
+      email: "riley@old.com",
+      _count: { transactions: 12, engagements: 3, accountSubscriptions: 0, assignedUsers: 1 },
+    });
+
+    const description = mergeDescription(remove, "left", "right");
+
+    expect(description).toContain("The contact on the right (riley@old.com) will be permanently deleted.");
+    expect(description).toContain(
+      "12 transactions, 3 engagements and 1 assignment will move to the contact on the left.",
+    );
+    expect(description).toContain("This cannot be undone.");
+  });
+
+  it("singularizes a count of one and omits relations with nothing to move", () => {
+    const remove = buildPaired({
+      id: "b",
+      email: "riley@old.com",
+      _count: { transactions: 1, engagements: 0, accountSubscriptions: 0, assignedUsers: 0 },
+    });
+
+    const description = mergeDescription(remove, "left", "right");
+
+    expect(description).toContain("1 transaction will move");
+    expect(description).not.toContain("engagement");
+  });
+
+  it("says so when there is nothing attached", () => {
+    const description = mergeDescription(buildPaired({ id: "b", email: "riley@old.com" }), "left", "right");
+
+    expect(description).toContain("It has nothing attached to move.");
+  });
+
+  it("warns about dropped rows only when subscriptions or assignments exist", () => {
+    const withSubs = mergeDescription(
+      buildPaired({
+        id: "b",
+        _count: { transactions: 0, engagements: 0, accountSubscriptions: 2, assignedUsers: 0 },
+      }),
+      "left",
+      "right",
+    );
+    const withoutSubs = mergeDescription(
+      buildPaired({ id: "b", _count: { transactions: 5, engagements: 0, accountSubscriptions: 0, assignedUsers: 0 } }),
+      "left",
+      "right",
+    );
+
+    expect(withSubs).toContain("deleted rather than moved");
+    expect(withoutSubs).not.toContain("deleted rather than moved");
+  });
+
+  it("falls back through alternate email to a placeholder when there is no primary", () => {
+    expect(mergeDescription(buildPaired({ id: "b", alternateEmail: "alt@x.com" }), "left", "right")).toContain(
+      "(alt@x.com)",
+    );
+    expect(mergeDescription(buildPaired({ id: "b" }), "left", "right")).toContain("(no email on file)");
+  });
+});

--- a/app/lib/contact-health.ts
+++ b/app/lib/contact-health.ts
@@ -1,0 +1,158 @@
+import { Prisma } from "@prisma/client";
+
+import { ContactType } from "~/lib/constants";
+
+export const contactHealthSelect = {
+  id: true,
+  firstName: true,
+  lastName: true,
+  organizationName: true,
+  email: true,
+  alternateEmail: true,
+  phone: true,
+  typeId: true,
+  type: { select: { name: true } },
+  user: { select: { id: true } },
+} satisfies Prisma.ContactSelect;
+
+export type HealthContact = Prisma.ContactGetPayload<{ select: typeof contactHealthSelect }>;
+
+export const mergeCountsSelect = {
+  transactions: true,
+  engagements: true,
+  accountSubscriptions: true,
+  assignedUsers: true,
+} satisfies Prisma.ContactCountOutputTypeSelect;
+
+export const pairedContactSelect = {
+  ...contactHealthSelect,
+  _count: { select: mergeCountsSelect },
+} satisfies Prisma.ContactSelect;
+
+/** A contact shown in a duplicate pair, where the merge confirmation needs its relation counts. */
+export type PairedContact = Prisma.ContactGetPayload<{ select: typeof pairedContactSelect }>;
+
+export type Pair<T> = [T, T];
+
+/** Stable identity for an unordered pair, used as the dismissal key in local storage. */
+export function pairKey(a: Pick<HealthContact, "id">, b: Pick<HealthContact, "id">) {
+  return [a.id, b.id].sort().join("-");
+}
+
+/** Organizations have no first or last name, so their name lives in a different column. */
+export function displayName(contact: Pick<HealthContact, "firstName" | "lastName" | "organizationName">) {
+  const personal = [contact.firstName, contact.lastName]
+    .map((part) => part?.trim() ?? "")
+    .filter(Boolean)
+    .join(" ");
+  return personal || contact.organizationName?.trim() || "";
+}
+
+function nameKey(contact: HealthContact) {
+  return displayName(contact).toLowerCase();
+}
+
+/**
+ * A merge deletes one of the pair, and `User.contact` cascades, so removing a contact that backs a
+ * login would take the user account with it. Such a contact can be the keeper but never the one
+ * deleted.
+ */
+export function canBeDeleted(contact: Pick<HealthContact, "user">) {
+  return contact.user === null;
+}
+
+export function isMergeablePair<T extends Pick<HealthContact, "user">>([a, b]: Pair<T>) {
+  return canBeDeleted(a) || canBeDeleted(b);
+}
+
+/** Contacts sharing a normalized name, as every unordered pair within each matching group. */
+export function findNameDuplicates(contacts: Array<HealthContact>): Array<Pair<HealthContact>> {
+  const byName = new Map<string, Array<HealthContact>>();
+  for (const contact of contacts) {
+    const key = nameKey(contact);
+    if (!key) continue;
+    const group = byName.get(key) ?? [];
+    group.push(contact);
+    byName.set(key, group);
+  }
+
+  const pairs: Array<Pair<HealthContact>> = [];
+  for (const group of byName.values()) {
+    for (let i = 0; i < group.length - 1; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        pairs.push([group[i], group[j]]);
+      }
+    }
+  }
+  return pairs;
+}
+
+/** One contact's alternate email matching another's primary, reported once per unordered pair. */
+export function findEmailCrossDuplicates(contacts: Array<HealthContact>): Array<Pair<HealthContact>> {
+  const byPrimaryEmail = new Map<string, HealthContact>();
+  for (const contact of contacts) {
+    if (contact.email) byPrimaryEmail.set(contact.email.toLowerCase(), contact);
+  }
+
+  const pairs: Array<Pair<HealthContact>> = [];
+  const seen = new Set<string>();
+  for (const contact of contacts) {
+    if (!contact.alternateEmail) continue;
+    const match = byPrimaryEmail.get(contact.alternateEmail.toLowerCase());
+    if (!match || match.id === contact.id) continue;
+
+    const key = [contact.id, match.id].sort().join("|");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    pairs.push([contact, match]);
+  }
+  return pairs;
+}
+
+/** Only donors are chased for an address — the rest legitimately have no email on file. */
+const TYPES_NEEDING_EMAIL: ReadonlySet<number> = new Set([ContactType.Donor, ContactType.Donor_and_Missionary]);
+
+export function isMissingRequiredEmail(contact: Pick<HealthContact, "email" | "typeId">) {
+  return !contact.email && TYPES_NEEDING_EMAIL.has(contact.typeId);
+}
+
+function pluralize(count: number, noun: string) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function formatList(items: Array<string>) {
+  if (items.length === 1) return items[0];
+  return `${items.slice(0, -1).join(", ")} and ${items.at(-1)}`;
+}
+
+/** Duplicates usually share a name, so the confirmation identifies each side by position and email. */
+export function mergeDescription(remove: PairedContact, keepSide: string, removeSide: string) {
+  const identifier = remove.email ?? remove.alternateEmail ?? "no email on file";
+  const moving = [
+    { count: remove._count.transactions, noun: "transaction" },
+    { count: remove._count.engagements, noun: "engagement" },
+    { count: remove._count.accountSubscriptions, noun: "subscription" },
+    { count: remove._count.assignedUsers, noun: "assignment" },
+  ]
+    .filter((item) => item.count > 0)
+    .map((item) => pluralize(item.count, item.noun));
+
+  const sentences = [`The contact on the ${removeSide} (${identifier}) will be permanently deleted.`];
+
+  if (moving.length > 0) {
+    sentences.push(`${formatList(moving)} will move to the contact on the ${keepSide}.`);
+  } else {
+    sentences.push("It has nothing attached to move.");
+  }
+
+  // Both relations are uniquely constrained on the contact, so a row that would collide with one the
+  // keeper already has can't be re-pointed and is deleted instead.
+  if (remove._count.accountSubscriptions > 0 || remove._count.assignedUsers > 0) {
+    sentences.push(
+      "Its subscriptions and assignments that duplicate one the kept contact already has will be deleted rather than moved.",
+    );
+  }
+
+  sentences.push("This cannot be undone.");
+  return sentences.join(" ");
+}

--- a/app/routes/_app.contacts.$contactId.edit.tsx
+++ b/app/routes/_app.contacts.$contactId.edit.tsx
@@ -225,7 +225,7 @@ export default function EditContactPage() {
       alternatePhone: contact.alternatePhone ?? "",
       organizationName: contact.organizationName ?? "",
       assignedUserIds: contact.assignedUsers.map((a) => a.userId),
-      typeId: "",
+      typeId: contact.typeId ?? "",
       address: contact.address
         ? {
             street: contact.address.street,

--- a/app/routes/_app.contacts._index.tsx
+++ b/app/routes/_app.contacts._index.tsx
@@ -1,4 +1,4 @@
-import { IconPlus } from "@tabler/icons-react";
+import { IconHeartbeat, IconPlus } from "@tabler/icons-react";
 import type { LoaderFunctionArgs } from "react-router";
 import { Form, Link, useLoaderData, useSearchParams, useSubmit } from "react-router";
 
@@ -9,6 +9,7 @@ import { PageContainer } from "~/components/page-container";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import { Label } from "~/components/ui/label";
+import { useUser } from "~/hooks/useUser";
 import { db } from "~/integrations/prisma.server";
 import { handleLoaderError } from "~/lib/responses.server";
 import { SessionService } from "~/services.server/session";
@@ -58,6 +59,7 @@ export async function loader(args: LoaderFunctionArgs) {
 
 export default function ContactIndexPage() {
   const { contacts } = useLoaderData<typeof loader>();
+  const user = useUser();
   const submit = useSubmit();
   const [searchParams] = useSearchParams();
 
@@ -65,12 +67,22 @@ export default function ContactIndexPage() {
     <>
       <title>Contacts</title>
       <PageHeader title="Contacts">
-        <Button asChild>
-          <Link to="/contacts/new" prefetch="intent">
-            <IconPlus className="mr-2 size-5" />
-            <span>New Contact</span>
-          </Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          {user.isAdmin ? (
+            <Button asChild variant="ghost">
+              <Link to="/contacts/health" prefetch="intent">
+                <IconHeartbeat className="mr-2 size-5" />
+                <span>Contact Health</span>
+              </Link>
+            </Button>
+          ) : null}
+          <Button asChild>
+            <Link to="/contacts/new" prefetch="intent">
+              <IconPlus className="mr-2 size-5" />
+              <span>New Contact</span>
+            </Link>
+          </Button>
+        </div>
       </PageHeader>
 
       <PageContainer>

--- a/app/routes/_app.contacts.health.tsx
+++ b/app/routes/_app.contacts.health.tsx
@@ -124,7 +124,7 @@ export async function action(args: ActionFunctionArgs) {
           id: true,
           address: { select: { id: true } },
           accountSubscriptions: { select: { id: true, accountId: true } },
-          contactAssignments: { select: { id: true, userId: true } },
+          assignedUsers: { select: { id: true, userId: true } },
         },
       }),
     ]);
@@ -162,14 +162,14 @@ export async function action(args: ActionFunctionArgs) {
       }
 
       // Transfer contact assignments (skip ones the keeper already has)
-      const assignsToTransfer = remove.contactAssignments.filter((a) => !keeperUserIds.has(a.userId));
+      const assignsToTransfer = remove.assignedUsers.filter((a) => !keeperUserIds.has(a.userId));
       if (assignsToTransfer.length > 0) {
         await tx.contactAssigment.updateMany({
           where: { id: { in: assignsToTransfer.map((a) => a.id) } },
           data: { contactId: keepId },
         });
       }
-      const assignsToDrop = remove.contactAssignments.filter((a) => keeperUserIds.has(a.userId));
+      const assignsToDrop = remove.assignedUsers.filter((a) => keeperUserIds.has(a.userId));
       if (assignsToDrop.length > 0) {
         await tx.contactAssigment.deleteMany({ where: { id: { in: assignsToDrop.map((a) => a.id) } } });
       }
@@ -197,7 +197,10 @@ export async function action(args: ActionFunctionArgs) {
   } catch (error) {
     logger.error("Error merging contacts", { error });
     Sentry.captureException(error);
-    return Toasts.dataWithError(null, { message: "Error", description: "An unknown error occurred. Please try again." });
+    return Toasts.dataWithError(null, {
+      message: "Error",
+      description: "An unknown error occurred. Please try again.",
+    });
   }
 }
 
@@ -206,8 +209,7 @@ export default function ContactHealthPage() {
   const [dismissed, setDismissed] = useState<Set<string>>(new Set());
 
   const pairKey = (a: ContactSummary, b: ContactSummary) => [a.id, b.id].sort().join("|");
-  const dismiss = (a: ContactSummary, b: ContactSummary) =>
-    setDismissed((prev) => new Set([...prev, pairKey(a, b)]));
+  const dismiss = (a: ContactSummary, b: ContactSummary) => setDismissed((prev) => new Set([...prev, pairKey(a, b)]));
   const isDismissed = (a: ContactSummary, b: ContactSummary) => dismissed.has(pairKey(a, b));
 
   const visibleNameDups = nameDuplicates.filter(([a, b]) => !isDismissed(a, b));
@@ -328,15 +330,7 @@ function Row({ label, value }: { label: string; value: string | null | undefined
   );
 }
 
-function DuplicatePairCard({
-  a,
-  b,
-  onDismiss,
-}: {
-  a: ContactSummary;
-  b: ContactSummary;
-  onDismiss: () => void;
-}) {
+function DuplicatePairCard({ a, b, onDismiss }: { a: ContactSummary; b: ContactSummary; onDismiss: () => void }) {
   return (
     <Card>
       <CardHeader className="pb-2">

--- a/app/routes/_app.contacts.health.tsx
+++ b/app/routes/_app.contacts.health.tsx
@@ -1,0 +1,390 @@
+import { IconAlertTriangle, IconCheck, IconUsers, IconX } from "@tabler/icons-react";
+import { useState } from "react";
+import { ActionFunctionArgs, Form, Link, LoaderFunctionArgs, useLoaderData } from "react-router";
+import { z } from "zod/v4";
+
+import { PageHeader } from "~/components/common/page-header";
+import { ErrorComponent } from "~/components/error-component";
+import { PageContainer } from "~/components/page-container";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Callout } from "~/components/ui/callout";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { Separator } from "~/components/ui/separator";
+import { createLogger } from "~/integrations/logger.server";
+import { db } from "~/integrations/prisma.server";
+import { Sentry } from "~/integrations/sentry";
+import { Toasts } from "~/lib/toast.server";
+import { formatPhoneNumber } from "~/lib/utils";
+import { SessionService } from "~/services.server/session";
+
+const logger = createLogger("Routes.ContactHealth");
+
+const mergeSchema = z.object({
+  _action: z.literal("merge"),
+  keepId: z.string().min(1),
+  deleteId: z.string().min(1),
+});
+
+type ContactSummary = {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  alternateEmail: string | null;
+  phone: string | null;
+  type: { name: string };
+  _count: { transactions: number; accountSubscriptions: number };
+};
+
+export async function loader(args: LoaderFunctionArgs) {
+  await SessionService.requireAdmin(args);
+  const orgId = await SessionService.requireOrgId(args);
+
+  const contacts = await db.contact.findMany({
+    where: { orgId },
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      email: true,
+      alternateEmail: true,
+      phone: true,
+      type: { select: { name: true } },
+      _count: { select: { transactions: true, accountSubscriptions: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  // Name duplicates: same normalized full name
+  const nameMap = new Map<string, ContactSummary[]>();
+  for (const c of contacts) {
+    const key = `${(c.firstName ?? "").trim()} ${(c.lastName ?? "").trim()}`.toLowerCase().trim();
+    if (!key || key === " ") continue;
+    const group = nameMap.get(key) ?? [];
+    group.push(c);
+    nameMap.set(key, group);
+  }
+  const nameDuplicates: Array<[ContactSummary, ContactSummary]> = [];
+  for (const group of nameMap.values()) {
+    if (group.length < 2) continue;
+    // Emit pairs
+    for (let i = 0; i < group.length - 1; i++) {
+      for (let j = i + 1; j < group.length; j++) {
+        nameDuplicates.push([group[i], group[j]]);
+      }
+    }
+  }
+
+  // Also check cross-email: contact A's email matches contact B's alternateEmail
+  const emailToContact = new Map<string, ContactSummary>();
+  for (const c of contacts) {
+    if (c.email) emailToContact.set(c.email.toLowerCase(), c);
+  }
+  const emailCrossDuplicates: Array<[ContactSummary, ContactSummary]> = [];
+  for (const c of contacts) {
+    if (!c.alternateEmail) continue;
+    const match = emailToContact.get(c.alternateEmail.toLowerCase());
+    if (match && match.id !== c.id) {
+      // Avoid double-reporting
+      const alreadyReported = emailCrossDuplicates.some(
+        ([a, b]) => (a.id === c.id && b.id === match.id) || (a.id === match.id && b.id === c.id),
+      );
+      if (!alreadyReported) {
+        emailCrossDuplicates.push([c, match]);
+      }
+    }
+  }
+
+  // Incomplete: missing email
+  const missingEmail = contacts.filter((c) => !c.email);
+
+  return { nameDuplicates, emailCrossDuplicates, missingEmail };
+}
+
+export async function action(args: ActionFunctionArgs) {
+  const user = await SessionService.requireAdmin(args);
+  const orgId = await SessionService.requireOrgId(args);
+
+  const data = Object.fromEntries(await args.request.formData());
+  const result = mergeSchema.safeParse(data);
+  if (!result.success) {
+    return Toasts.dataWithError(null, { message: "Invalid request" });
+  }
+
+  const { keepId, deleteId } = result.data;
+
+  try {
+    // Verify both contacts belong to this org
+    const [keep, remove] = await Promise.all([
+      db.contact.findUniqueOrThrow({ where: { id: keepId, orgId }, select: { id: true } }),
+      db.contact.findUniqueOrThrow({
+        where: { id: deleteId, orgId },
+        select: {
+          id: true,
+          address: { select: { id: true } },
+          accountSubscriptions: { select: { id: true, accountId: true } },
+          contactAssignments: { select: { id: true, userId: true } },
+        },
+      }),
+    ]);
+
+    // Find which subscriptions and assignments the keeper already has (to avoid unique conflicts)
+    const keeperSubscriptions = await db.accountSubscription.findMany({
+      where: { subscriberId: keep.id },
+      select: { accountId: true },
+    });
+    const keeperAssignments = await db.contactAssigment.findMany({
+      where: { contactId: keep.id },
+      select: { userId: true },
+    });
+    const keeperAccountIds = new Set(keeperSubscriptions.map((s) => s.accountId));
+    const keeperUserIds = new Set(keeperAssignments.map((a) => a.userId));
+
+    await db.$transaction(async (tx) => {
+      // Transfer transactions
+      await tx.transaction.updateMany({ where: { contactId: deleteId }, data: { contactId: keepId } });
+
+      // Transfer engagements
+      await tx.engagement.updateMany({ where: { contactId: deleteId }, data: { contactId: keepId } });
+
+      // Transfer account subscriptions (skip ones the keeper already has)
+      const subsToTransfer = remove.accountSubscriptions.filter((s) => !keeperAccountIds.has(s.accountId));
+      if (subsToTransfer.length > 0) {
+        await tx.accountSubscription.updateMany({
+          where: { id: { in: subsToTransfer.map((s) => s.id) } },
+          data: { subscriberId: keepId },
+        });
+      }
+      const subsToDrop = remove.accountSubscriptions.filter((s) => keeperAccountIds.has(s.accountId));
+      if (subsToDrop.length > 0) {
+        await tx.accountSubscription.deleteMany({ where: { id: { in: subsToDrop.map((s) => s.id) } } });
+      }
+
+      // Transfer contact assignments (skip ones the keeper already has)
+      const assignsToTransfer = remove.contactAssignments.filter((a) => !keeperUserIds.has(a.userId));
+      if (assignsToTransfer.length > 0) {
+        await tx.contactAssigment.updateMany({
+          where: { id: { in: assignsToTransfer.map((a) => a.id) } },
+          data: { contactId: keepId },
+        });
+      }
+      const assignsToDrop = remove.contactAssignments.filter((a) => keeperUserIds.has(a.userId));
+      if (assignsToDrop.length > 0) {
+        await tx.contactAssigment.deleteMany({ where: { id: { in: assignsToDrop.map((a) => a.id) } } });
+      }
+
+      // Transfer address if keeper has none
+      if (remove.address) {
+        const keeperAddress = await tx.address.findUnique({ where: { contactId: keepId } });
+        if (!keeperAddress) {
+          await tx.address.update({ where: { id: remove.address.id }, data: { contactId: keepId } });
+        } else {
+          await tx.address.delete({ where: { id: remove.address.id } });
+        }
+      }
+
+      // Delete the duplicate contact (cascades receipts link)
+      await tx.contact.delete({ where: { id: deleteId } });
+    });
+
+    logger.info("Contacts merged", { keepId, deleteId, adminUsername: user.username });
+
+    return Toasts.dataWithSuccess(null, {
+      message: "Contacts merged",
+      description: "All transactions, engagements, and subscriptions have been transferred.",
+    });
+  } catch (error) {
+    logger.error("Error merging contacts", { error });
+    Sentry.captureException(error);
+    return Toasts.dataWithError(null, { message: "Error", description: "An unknown error occurred. Please try again." });
+  }
+}
+
+export default function ContactHealthPage() {
+  const { nameDuplicates, emailCrossDuplicates, missingEmail } = useLoaderData<typeof loader>();
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+
+  const pairKey = (a: ContactSummary, b: ContactSummary) => [a.id, b.id].sort().join("|");
+  const dismiss = (a: ContactSummary, b: ContactSummary) =>
+    setDismissed((prev) => new Set([...prev, pairKey(a, b)]));
+  const isDismissed = (a: ContactSummary, b: ContactSummary) => dismissed.has(pairKey(a, b));
+
+  const visibleNameDups = nameDuplicates.filter(([a, b]) => !isDismissed(a, b));
+  const visibleEmailDups = emailCrossDuplicates.filter(([a, b]) => !isDismissed(a, b));
+  const totalIssues = visibleNameDups.length + visibleEmailDups.length + missingEmail.length;
+
+  return (
+    <>
+      <title>Contact Health</title>
+      <PageHeader title="Contact Health">
+        <Button variant="outline" asChild>
+          <Link to="/contacts" prefetch="intent">
+            Back to Contacts
+          </Link>
+        </Button>
+      </PageHeader>
+
+      <PageContainer className="max-w-4xl">
+        {totalIssues === 0 ? (
+          <Callout variant="info">
+            <div className="flex items-center gap-2">
+              <IconCheck className="size-4" />
+              <span>No issues found. Your contacts database looks clean.</span>
+            </div>
+          </Callout>
+        ) : (
+          <p className="text-muted-foreground mb-6 text-sm">
+            {totalIssues} issue{totalIssues === 1 ? "" : "s"} found. Review and resolve each one below.
+          </p>
+        )}
+
+        {visibleNameDups.length > 0 ? (
+          <section className="mb-10">
+            <h2 className="mb-1 text-lg font-medium">Same name</h2>
+            <p className="text-muted-foreground mb-4 text-sm">
+              These contacts share an identical name and may be duplicates.
+            </p>
+            <div className="space-y-4">
+              {visibleNameDups.map(([a, b]) => (
+                <DuplicatePairCard key={pairKey(a, b)} a={a} b={b} onDismiss={() => dismiss(a, b)} />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {visibleEmailDups.length > 0 ? (
+          <section className="mb-10">
+            <h2 className="mb-1 text-lg font-medium">Overlapping email addresses</h2>
+            <p className="text-muted-foreground mb-4 text-sm">
+              One contact's primary email matches another's alternate email.
+            </p>
+            <div className="space-y-4">
+              {visibleEmailDups.map(([a, b]) => (
+                <DuplicatePairCard key={pairKey(a, b)} a={a} b={b} onDismiss={() => dismiss(a, b)} />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {missingEmail.length > 0 ? (
+          <section className="mb-10">
+            <h2 className="mb-1 text-lg font-medium">Missing email</h2>
+            <p className="text-muted-foreground mb-4 text-sm">
+              These contacts have no email address on file. Donors need an email for giving receipts.
+            </p>
+            <div className="divide-border divide-y rounded-md border">
+              {missingEmail.map((c) => (
+                <div key={c.id} className="flex items-center justify-between px-4 py-3 text-sm">
+                  <div>
+                    <span className="font-medium">
+                      {c.firstName} {c.lastName}
+                    </span>
+                    <span className="text-muted-foreground ml-2">{c.type.name}</span>
+                  </div>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link to={`/contacts/${c.id}/edit`} prefetch="intent">
+                      Edit
+                    </Link>
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </PageContainer>
+    </>
+  );
+}
+
+function ContactColumn({ contact }: { contact: ContactSummary }) {
+  const name = [contact.firstName, contact.lastName].filter(Boolean).join(" ") || "—";
+  return (
+    <div className="space-y-2 text-sm">
+      <p className="font-medium">{name}</p>
+      <dl className="space-y-1">
+        <Row label="Type" value={contact.type.name} />
+        <Row label="Email" value={contact.email} />
+        {contact.alternateEmail ? <Row label="Alt email" value={contact.alternateEmail} /> : null}
+        <Row label="Phone" value={contact.phone ? formatPhoneNumber(contact.phone) : null} />
+        <Row label="Transactions" value={String(contact._count.transactions)} />
+        <Row label="Subscriptions" value={String(contact._count.accountSubscriptions)} />
+      </dl>
+      <Button variant="outline" size="sm" asChild>
+        <Link to={`/contacts/${contact.id}`} prefetch="intent">
+          View
+        </Link>
+      </Button>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string | null | undefined }) {
+  return (
+    <div className="grid grid-cols-[100px_1fr] gap-1">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className={value ? "" : "text-muted-foreground"}>{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+function DuplicatePairCard({
+  a,
+  b,
+  onDismiss,
+}: {
+  a: ContactSummary;
+  b: ContactSummary;
+  onDismiss: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="flex items-center gap-2 text-base">
+            <IconAlertTriangle className="text-warning size-4" aria-hidden="true" />
+            Possible duplicate
+          </CardTitle>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
+            aria-label="Not a duplicate"
+          >
+            <IconX className="size-3.5" aria-hidden="true" />
+            Not a duplicate
+          </button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 gap-4">
+          <ContactColumn contact={a} />
+          <ContactColumn contact={b} />
+        </div>
+        <Separator className="my-4" />
+        <div className="flex flex-wrap gap-2">
+          <MergeForm keepId={a.id} deleteId={b.id} label={`Keep left, remove right`} />
+          <MergeForm keepId={b.id} deleteId={a.id} label={`Keep right, remove left`} />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MergeForm({ keepId, deleteId, label }: { keepId: string; deleteId: string; label: string }) {
+  return (
+    <Form method="post">
+      <input type="hidden" name="_action" value="merge" />
+      <input type="hidden" name="keepId" value={keepId} />
+      <input type="hidden" name="deleteId" value={deleteId} />
+      <Button type="submit" variant="outline" size="sm" className="flex items-center gap-1.5">
+        <IconUsers className="size-3.5" aria-hidden="true" />
+        {label}
+      </Button>
+    </Form>
+  );
+}
+
+export function ErrorBoundary() {
+  return <ErrorComponent />;
+}

--- a/app/routes/_app.contacts.health.tsx
+++ b/app/routes/_app.contacts.health.tsx
@@ -1,10 +1,13 @@
+import { Prisma } from "@prisma/client";
 import { IconAlertTriangle, IconCheck, IconUsers, IconX } from "@tabler/icons-react";
-import { useState } from "react";
-import { ActionFunctionArgs, Form, Link, LoaderFunctionArgs, useLoaderData } from "react-router";
+import { useEffect, useMemo } from "react";
+import { ActionFunctionArgs, Link, LoaderFunctionArgs, useLoaderData } from "react-router";
+import { useLocalStorage } from "usehooks-ts";
 import { z } from "zod/v4";
 
 import { PageHeader } from "~/components/common/page-header";
 import { ErrorComponent } from "~/components/error-component";
+import { ConfirmDestructiveModal } from "~/components/modals/confirm-destructive-modal";
 import { PageContainer } from "~/components/page-container";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -14,11 +17,30 @@ import { Separator } from "~/components/ui/separator";
 import { createLogger } from "~/integrations/logger.server";
 import { db } from "~/integrations/prisma.server";
 import { Sentry } from "~/integrations/sentry";
+import {
+  canBeDeleted,
+  contactHealthSelect,
+  displayName,
+  findEmailCrossDuplicates,
+  findNameDuplicates,
+  type HealthContact,
+  isMergeablePair,
+  isMissingRequiredEmail,
+  mergeCountsSelect,
+  mergeDescription,
+  type Pair,
+  type PairedContact,
+  pairKey,
+} from "~/lib/contact-health";
+import { handleLoaderError } from "~/lib/responses.server";
 import { Toasts } from "~/lib/toast.server";
 import { formatPhoneNumber } from "~/lib/utils";
 import { SessionService } from "~/services.server/session";
 
 const logger = createLogger("Routes.ContactHealth");
+
+/** Dismissals are one admin's judgement about their own screen, so they stay in the browser. */
+const DISMISSED_STORAGE_KEY = "contact-health-dismissed";
 
 const mergeSchema = z.object({
   _action: z.literal("merge"),
@@ -26,81 +48,63 @@ const mergeSchema = z.object({
   deleteId: z.string().min(1),
 });
 
-type ContactSummary = {
-  id: string;
-  firstName: string | null;
-  lastName: string | null;
-  email: string | null;
-  alternateEmail: string | null;
-  phone: string | null;
-  type: { name: string };
-  _count: { transactions: number; accountSubscriptions: number };
-};
-
 export async function loader(args: LoaderFunctionArgs) {
   await SessionService.requireAdmin(args);
   const orgId = await SessionService.requireOrgId(args);
 
-  const contacts = await db.contact.findMany({
-    where: { orgId },
-    select: {
-      id: true,
-      firstName: true,
-      lastName: true,
-      email: true,
-      alternateEmail: true,
-      phone: true,
-      type: { select: { name: true } },
-      _count: { select: { transactions: true, accountSubscriptions: true } },
-    },
-    orderBy: { createdAt: "asc" },
-  });
+  // The session helpers throw Responses, which handleLoaderError would turn into a 500, so the guard
+  // only covers the queries below it.
+  try {
+    const contacts = await db.contact.findMany({
+      where: { orgId },
+      select: contactHealthSelect,
+      orderBy: { createdAt: "asc" },
+    });
 
-  // Name duplicates: same normalized full name
-  const nameMap = new Map<string, ContactSummary[]>();
-  for (const c of contacts) {
-    const key = `${(c.firstName ?? "").trim()} ${(c.lastName ?? "").trim()}`.toLowerCase().trim();
-    if (!key || key === " ") continue;
-    const group = nameMap.get(key) ?? [];
-    group.push(c);
-    nameMap.set(key, group);
-  }
-  const nameDuplicates: Array<[ContactSummary, ContactSummary]> = [];
-  for (const group of nameMap.values()) {
-    if (group.length < 2) continue;
-    // Emit pairs
-    for (let i = 0; i < group.length - 1; i++) {
-      for (let j = i + 1; j < group.length; j++) {
-        nameDuplicates.push([group[i], group[j]]);
-      }
-    }
-  }
+    const nameDuplicates = findNameDuplicates(contacts).filter(isMergeablePair);
+    const emailCrossDuplicates = findEmailCrossDuplicates(contacts).filter(isMergeablePair);
 
-  // Also check cross-email: contact A's email matches contact B's alternateEmail
-  const emailToContact = new Map<string, ContactSummary>();
-  for (const c of contacts) {
-    if (c.email) emailToContact.set(c.email.toLowerCase(), c);
-  }
-  const emailCrossDuplicates: Array<[ContactSummary, ContactSummary]> = [];
-  for (const c of contacts) {
-    if (!c.alternateEmail) continue;
-    const match = emailToContact.get(c.alternateEmail.toLowerCase());
-    if (match && match.id !== c.id) {
-      // Avoid double-reporting
-      const alreadyReported = emailCrossDuplicates.some(
-        ([a, b]) => (a.id === c.id && b.id === match.id) || (a.id === match.id && b.id === c.id),
-      );
-      if (!alreadyReported) {
-        emailCrossDuplicates.push([c, match]);
-      }
-    }
-  }
+    // Only the contacts that ended up in a pair need relation counts, and only the merge confirmation
+    // reads them. Counting every contact up front meant four correlated subqueries per row of a table
+    // that is almost entirely not duplicated.
+    const pairedIds = [...nameDuplicates, ...emailCrossDuplicates].flatMap(([a, b]) => [a.id, b.id]);
+    const counts = await db.contact.findMany({
+      where: { id: { in: [...new Set(pairedIds)] } },
+      select: { id: true, _count: { select: mergeCountsSelect } },
+    });
+    const countsById = new Map(counts.map((c) => [c.id, c._count]));
 
-  // Incomplete: missing email
-  const missingEmail = contacts.filter((c) => !c.email);
+    const withCounts = ([a, b]: Pair<HealthContact>): Pair<PairedContact> => [
+      { ...a, _count: countsById.get(a.id) ?? EMPTY_COUNTS },
+      { ...b, _count: countsById.get(b.id) ?? EMPTY_COUNTS },
+    ];
 
-  return { nameDuplicates, emailCrossDuplicates, missingEmail };
+    const missingEmail = contacts.filter(isMissingRequiredEmail);
+
+    logger.info("Contact health scanned", {
+      orgId,
+      contacts: contacts.length,
+      nameDuplicates: nameDuplicates.length,
+      emailCrossDuplicates: emailCrossDuplicates.length,
+      missingEmail: missingEmail.length,
+    });
+
+    return {
+      nameDuplicates: nameDuplicates.map(withCounts),
+      emailCrossDuplicates: emailCrossDuplicates.map(withCounts),
+      missingEmail,
+    };
+  } catch (e) {
+    handleLoaderError(e, args.request);
+  }
 }
+
+const EMPTY_COUNTS: PairedContact["_count"] = {
+  transactions: 0,
+  engagements: 0,
+  accountSubscriptions: 0,
+  assignedUsers: 0,
+};
 
 export async function action(args: ActionFunctionArgs) {
   const user = await SessionService.requireAdmin(args);
@@ -109,10 +113,21 @@ export async function action(args: ActionFunctionArgs) {
   const data = Object.fromEntries(await args.request.formData());
   const result = mergeSchema.safeParse(data);
   if (!result.success) {
-    return Toasts.dataWithError(null, { message: "Invalid request" });
+    logger.warn("Rejected malformed merge request", { orgId, issues: result.error.issues });
+    return Toasts.dataWithError({ success: false }, { message: "Invalid request" });
   }
 
   const { keepId, deleteId } = result.data;
+
+  // The page only ever pairs two distinct contacts, so this is a hand-made request. Without the
+  // guard the transfers would be no-ops and the delete would destroy the contact outright.
+  if (keepId === deleteId) {
+    logger.warn("Rejected merge of a contact into itself", { orgId, keepId });
+    return Toasts.dataWithError(
+      { success: false },
+      { message: "Can't merge", description: "A contact can't be merged into itself." },
+    );
+  }
 
   try {
     // Verify both contacts belong to this org
@@ -122,12 +137,25 @@ export async function action(args: ActionFunctionArgs) {
         where: { id: deleteId, orgId },
         select: {
           id: true,
+          user: { select: { id: true } },
           address: { select: { id: true } },
           accountSubscriptions: { select: { id: true, accountId: true } },
           assignedUsers: { select: { id: true, userId: true } },
         },
       }),
     ]);
+
+    // The loader never offers these, so this only catches a stale page or a hand-made request.
+    if (remove.user) {
+      logger.warn("Refused to merge a contact that backs a user account", { keepId, deleteId });
+      return Toasts.dataWithError(
+        { success: false },
+        {
+          message: "Can't merge",
+          description: "This contact belongs to a user account. Deactivate the user before merging it away.",
+        },
+      );
+    }
 
     // Find which subscriptions and assignments the keeper already has (to avoid unique conflicts)
     const keeperSubscriptions = await db.accountSubscription.findMany({
@@ -141,12 +169,27 @@ export async function action(args: ActionFunctionArgs) {
     const keeperAccountIds = new Set(keeperSubscriptions.map((s) => s.accountId));
     const keeperUserIds = new Set(keeperAssignments.map((a) => a.userId));
 
-    await db.$transaction(async (tx) => {
+    logger.info("Merging contacts", {
+      orgId,
+      keepId,
+      deleteId,
+      adminUsername: user.username,
+      subscriptions: remove.accountSubscriptions.length,
+      assignments: remove.assignedUsers.length,
+    });
+
+    const moved = await db.$transaction(async (tx) => {
       // Transfer transactions
-      await tx.transaction.updateMany({ where: { contactId: deleteId }, data: { contactId: keepId } });
+      const transactions = await tx.transaction.updateMany({
+        where: { contactId: deleteId },
+        data: { contactId: keepId },
+      });
 
       // Transfer engagements
-      await tx.engagement.updateMany({ where: { contactId: deleteId }, data: { contactId: keepId } });
+      const engagements = await tx.engagement.updateMany({
+        where: { contactId: deleteId },
+        data: { contactId: keepId },
+      });
 
       // Transfer account subscriptions (skip ones the keeper already has)
       const subsToTransfer = remove.accountSubscriptions.filter((s) => !keeperAccountIds.has(s.accountId));
@@ -175,42 +218,88 @@ export async function action(args: ActionFunctionArgs) {
       }
 
       // Transfer address if keeper has none
+      let address: "moved" | "deleted" | "none" = "none";
       if (remove.address) {
         const keeperAddress = await tx.address.findUnique({ where: { contactId: keepId } });
         if (!keeperAddress) {
           await tx.address.update({ where: { id: remove.address.id }, data: { contactId: keepId } });
+          address = "moved";
         } else {
           await tx.address.delete({ where: { id: remove.address.id } });
+          address = "deleted";
         }
       }
 
       // Delete the duplicate contact (cascades receipts link)
       await tx.contact.delete({ where: { id: deleteId } });
+
+      return {
+        transactions: transactions.count,
+        engagements: engagements.count,
+        subscriptionsMoved: subsToTransfer.length,
+        subscriptionsDropped: subsToDrop.length,
+        assignmentsMoved: assignsToTransfer.length,
+        assignmentsDropped: assignsToDrop.length,
+        address,
+      };
     });
 
-    logger.info("Contacts merged", { keepId, deleteId, adminUsername: user.username });
+    // The merge is irreversible and leaves no audit trail of its own, so the counts are the record.
+    logger.info("Contacts merged", { orgId, keepId, deleteId, adminUsername: user.username, ...moved });
 
-    return Toasts.dataWithSuccess(null, {
-      message: "Contacts merged",
-      description: "All transactions, engagements, and subscriptions have been transferred.",
-    });
+    return Toasts.dataWithSuccess(
+      { success: true },
+      {
+        message: "Contacts merged",
+        description: "All transactions, engagements, and subscriptions have been transferred.",
+      },
+    );
   } catch (error) {
-    logger.error("Error merging contacts", { error });
+    // findUniqueOrThrow misses when a contact was already merged away, or belongs to another org.
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+      logger.warn("Merge target not found in this org", { orgId, keepId, deleteId });
+      return Toasts.dataWithError(
+        { success: false },
+        {
+          message: "Can't merge",
+          description: "One of these contacts no longer exists. Refresh the page and try again.",
+        },
+      );
+    }
+
+    logger.error("Error merging contacts", { error, orgId, keepId, deleteId, adminUsername: user.username });
     Sentry.captureException(error);
-    return Toasts.dataWithError(null, {
-      message: "Error",
-      description: "An unknown error occurred. Please try again.",
-    });
+    return Toasts.dataWithError(
+      { success: false },
+      {
+        message: "Error",
+        description: "An unknown error occurred. Please try again.",
+      },
+    );
   }
 }
 
 export default function ContactHealthPage() {
   const { nameDuplicates, emailCrossDuplicates, missingEmail } = useLoaderData<typeof loader>();
-  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
+  const [dismissed, setDismissed] = useLocalStorage<Array<string>>(DISMISSED_STORAGE_KEY, []);
 
-  const pairKey = (a: ContactSummary, b: ContactSummary) => [a.id, b.id].sort().join("|");
-  const dismiss = (a: ContactSummary, b: ContactSummary) => setDismissed((prev) => new Set([...prev, pairKey(a, b)]));
-  const isDismissed = (a: ContactSummary, b: ContactSummary) => dismissed.has(pairKey(a, b));
+  const livePairKeys = useMemo(
+    () => new Set([...nameDuplicates, ...emailCrossDuplicates].map(([a, b]) => pairKey(a, b))),
+    [nameDuplicates, emailCrossDuplicates],
+  );
+
+  // A merged or deleted contact can never form a pair again, so its dismissal would sit in storage
+  // forever. Returning the same array when nothing is stale keeps this from writing on every load.
+  useEffect(() => {
+    setDismissed((prev) =>
+      prev.every((key) => livePairKeys.has(key)) ? prev : prev.filter((key) => livePairKeys.has(key)),
+    );
+  }, [livePairKeys, setDismissed]);
+
+  const dismissedKeys = useMemo(() => new Set(dismissed), [dismissed]);
+  const dismiss = (a: PairedContact, b: PairedContact) =>
+    setDismissed((prev) => [...new Set([...prev, pairKey(a, b)])]);
+  const isDismissed = (a: PairedContact, b: PairedContact) => dismissedKeys.has(pairKey(a, b));
 
   const visibleNameDups = nameDuplicates.filter(([a, b]) => !isDismissed(a, b));
   const visibleEmailDups = emailCrossDuplicates.filter(([a, b]) => !isDismissed(a, b));
@@ -220,11 +309,18 @@ export default function ContactHealthPage() {
     <>
       <title>Contact Health</title>
       <PageHeader title="Contact Health">
-        <Button variant="outline" asChild>
-          <Link to="/contacts" prefetch="intent">
-            Back to Contacts
-          </Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          {dismissed.length > 0 ? (
+            <Button variant="ghost" onClick={() => setDismissed([])}>
+              Restore {dismissed.length} dismissed
+            </Button>
+          ) : null}
+          <Button variant="outline" asChild>
+            <Link to="/contacts" prefetch="intent">
+              Back to Contacts
+            </Link>
+          </Button>
+        </div>
       </PageHeader>
 
       <PageContainer className="max-w-4xl">
@@ -273,15 +369,14 @@ export default function ContactHealthPage() {
           <section className="mb-10">
             <h2 className="mb-1 text-lg font-medium">Missing email</h2>
             <p className="text-muted-foreground mb-4 text-sm">
-              These contacts have no email address on file. Donors need an email for giving receipts.
+              These donors have no email address on file, so they can't be sent a giving receipt. Other contact types
+              are not listed here.
             </p>
             <div className="divide-border divide-y rounded-md border">
               {missingEmail.map((c) => (
                 <div key={c.id} className="flex items-center justify-between px-4 py-3 text-sm">
                   <div>
-                    <span className="font-medium">
-                      {c.firstName} {c.lastName}
-                    </span>
+                    <span className="font-medium">{displayName(c) || "—"}</span>
                     <span className="text-muted-foreground ml-2">{c.type.name}</span>
                   </div>
                   <Button variant="outline" size="sm" asChild>
@@ -299,11 +394,14 @@ export default function ContactHealthPage() {
   );
 }
 
-function ContactColumn({ contact }: { contact: ContactSummary }) {
-  const name = [contact.firstName, contact.lastName].filter(Boolean).join(" ") || "—";
+function ContactColumn({ contact }: { contact: PairedContact }) {
+  const name = displayName(contact) || "—";
   return (
     <div className="space-y-2 text-sm">
-      <p className="font-medium">{name}</p>
+      <div className="flex flex-wrap items-center gap-2">
+        <p className="font-medium">{name}</p>
+        {contact.user ? <Badge variant="secondary">User account</Badge> : null}
+      </div>
       <dl className="space-y-1">
         <Row label="Type" value={contact.type.name} />
         <Row label="Email" value={contact.email} />
@@ -330,7 +428,7 @@ function Row({ label, value }: { label: string; value: string | null | undefined
   );
 }
 
-function DuplicatePairCard({ a, b, onDismiss }: { a: ContactSummary; b: ContactSummary; onDismiss: () => void }) {
+function DuplicatePairCard({ a, b, onDismiss }: { a: PairedContact; b: PairedContact; onDismiss: () => void }) {
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -357,25 +455,41 @@ function DuplicatePairCard({ a, b, onDismiss }: { a: ContactSummary; b: ContactS
         </div>
         <Separator className="my-4" />
         <div className="flex flex-wrap gap-2">
-          <MergeForm keepId={a.id} deleteId={b.id} label={`Keep left, remove right`} />
-          <MergeForm keepId={b.id} deleteId={a.id} label={`Keep right, remove left`} />
+          {canBeDeleted(b) ? <MergeAction keep={a} remove={b} keepSide="left" removeSide="right" /> : null}
+          {canBeDeleted(a) ? <MergeAction keep={b} remove={a} keepSide="right" removeSide="left" /> : null}
         </div>
+        {canBeDeleted(a) && canBeDeleted(b) ? null : (
+          <p className="text-muted-foreground mt-2 text-xs">
+            Only one direction is offered: a contact attached to a user account can be kept, but removing it would
+            delete the account.
+          </p>
+        )}
       </CardContent>
     </Card>
   );
 }
 
-function MergeForm({ keepId, deleteId, label }: { keepId: string; deleteId: string; label: string }) {
+function MergeAction({
+  keep,
+  remove,
+  keepSide,
+  removeSide,
+}: {
+  keep: PairedContact;
+  remove: PairedContact;
+  keepSide: string;
+  removeSide: string;
+}) {
   return (
-    <Form method="post">
-      <input type="hidden" name="_action" value="merge" />
-      <input type="hidden" name="keepId" value={keepId} />
-      <input type="hidden" name="deleteId" value={deleteId} />
-      <Button type="submit" variant="outline" size="sm" className="flex items-center gap-1.5">
-        <IconUsers className="size-3.5" aria-hidden="true" />
-        {label}
-      </Button>
-    </Form>
+    <ConfirmDestructiveModal
+      method="post"
+      actionValue="merge"
+      fields={{ keepId: keep.id, deleteId: remove.id }}
+      triggerLabel={`Keep ${keepSide}, remove ${removeSide}`}
+      triggerIcon={<IconUsers className="size-3.5" aria-hidden="true" />}
+      confirmLabel="Merge contacts"
+      description={mergeDescription(remove, keepSide, removeSide)}
+    />
   );
 }
 

--- a/app/server/middleware.ts
+++ b/app/server/middleware.ts
@@ -4,11 +4,15 @@ import { createMiddleware } from "hono/factory";
 import { isbot } from "isbot";
 
 import { httpLogger } from "~/integrations/logger.server";
+import { CONFIG } from "~/lib/env.server";
 
 const matchers = ["/assets", "favicon", ".well-known", "site.webmanifest", "sitemap.xml", "robots.txt"];
 
 export function loggerMiddleware() {
   return createMiddleware(async (c, next) => {
+    if (CONFIG.isDev) {
+      return next();
+    }
     if (matchers.some((m) => c.req.url.includes(m))) {
       return next();
     }


### PR DESCRIPTION
## Summary
New admin-only route at `/contacts/health` that surfaces data quality issues in the contacts database.

**Detects:**
- Same-name duplicates (normalized firstName + lastName match)
- Email cross-duplicates (one contact's alternate email matches another's primary email)
- Contacts with no email address

**Merge action:**
- Atomically transfers transactions, engagements, account subscriptions, and contact assignments to the keeper contact
- Skips transfers that would violate unique constraints (keeper already has that subscription/assignment)
- Deletes the duplicate contact
- Logs the merge server-side

**UI:**
- Side-by-side contact comparison cards
- "Not a duplicate" client-side dismiss (no server round-trip)
- Links to edit individual contacts for missing email fixes

## Test plan
- [ ] Visit `/contacts/health` as admin — issues render correctly
- [ ] Merge two duplicate contacts → transactions transfer, duplicate deleted
- [ ] Merge where keeper already has a subscription → no constraint error
- [ ] "Not a duplicate" dismiss hides the pair without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)