### PR TITLE
PR 7: Donation import — preview, deduplication, and execution

### DIFF
--- a/app/lib/tithely-import.test.ts
+++ b/app/lib/tithely-import.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { autoDetectMapping, missingRequiredFields, normalizeHeader, UNMAPPED } from "~/lib/tithely-import";
+import { TransactionItemMethod } from "~/lib/constants";
+import {
+  analyzeRecords,
+  autoDetectMapping,
+  contactLabel,
+  distinctFunds,
+  findDuplicateTransaction,
+  matchContact,
+  matchPaymentMethod,
+  missingRequiredFields,
+  normalizeHeader,
+  parseImportDate,
+  toImportRecords,
+  UNMAPPED,
+  type ImportRecord,
+} from "~/lib/tithely-import";
 
 describe("normalizeHeader", () => {
   it("lowercases and strips non-alphanumerics", () => {
@@ -39,5 +54,209 @@ describe("missingRequiredFields", () => {
   it("is empty once date and amount are mapped", () => {
     const mapping = autoDetectMapping(["Date", "Amount"]);
     expect(missingRequiredFields(mapping)).toEqual([]);
+  });
+});
+
+describe("parseImportDate", () => {
+  it("accepts the formats Tithe.ly and spreadsheets produce", () => {
+    expect(parseImportDate("2026-03-04")).toBe("2026-03-04");
+    expect(parseImportDate("3/4/2026")).toBe("2026-03-04");
+    expect(parseImportDate("03/04/2026")).toBe("2026-03-04");
+    expect(parseImportDate("2026-03-04T12:30:00Z")).toBe("2026-03-04");
+  });
+
+  it("returns null for blank or unparseable values", () => {
+    expect(parseImportDate("")).toBeNull();
+    expect(parseImportDate("   ")).toBeNull();
+    expect(parseImportDate("not a date")).toBeNull();
+    expect(parseImportDate(null)).toBeNull();
+  });
+});
+
+describe("toImportRecords", () => {
+  const mapping = autoDetectMapping(["Date", "Amount", "First Name", "Last Name", "Email", "Fund"]);
+
+  it("normalizes valid rows and reports unusable ones", () => {
+    const parsed = {
+      headers: ["Date", "Amount", "First Name", "Last Name", "Email", "Fund"],
+      rows: [
+        ["3/4/2026", "$1,250.00", "Jane", "Doe", "jane@example.com", "General"],
+        ["bad date", "$50.00", "Bob", "Smith", "", "General"],
+        ["3/5/2026", "", "Ann", "Lee", "", "General"],
+        ["3/6/2026", "$0.00", "Zero", "Gift", "", "General"],
+      ],
+    };
+
+    const { records, errors } = toImportRecords(parsed, mapping);
+
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      rowIndex: 0,
+      date: "2026-03-04",
+      amountInCents: 125000,
+      firstName: "Jane",
+      email: "jane@example.com",
+      fund: "General",
+    });
+    expect(errors.map((e) => e.rowIndex)).toEqual([1, 2, 3]);
+  });
+
+  it("ignores fully blank rows without reporting an error", () => {
+    const parsed = {
+      headers: ["Date", "Amount", "First Name", "Last Name", "Email", "Fund"],
+      rows: [["", "", "", "", "", ""]],
+    };
+    const { records, errors } = toImportRecords(parsed, mapping);
+    expect(records).toEqual([]);
+    expect(errors).toEqual([]);
+  });
+
+  it("leaves unmapped optional fields null", () => {
+    const dateAmountOnly = autoDetectMapping(["Date", "Amount"]);
+    const parsed = { headers: ["Date", "Amount"], rows: [["3/4/2026", "10"]] };
+    const { records } = toImportRecords(parsed, dateAmountOnly);
+    expect(records[0].email).toBeNull();
+    expect(records[0].fund).toBeNull();
+  });
+});
+
+describe("distinctFunds", () => {
+  it("returns unique fund names in first-seen order", () => {
+    const records = [{ fund: "General" }, { fund: "Missions" }, { fund: "General" }, { fund: null }];
+    expect(distinctFunds(records as Array<ImportRecord>)).toEqual(["General", "Missions"]);
+  });
+});
+
+describe("matchContact", () => {
+  const contacts = [
+    { id: "c1", firstName: "Jane", lastName: "Doe", email: "jane@example.com" },
+    { id: "c2", firstName: "Bob", lastName: "Smith", email: null },
+    { id: "c3", firstName: "Bob", lastName: "Smith", email: "other@example.com" },
+  ];
+
+  it("matches on email regardless of case", () => {
+    const match = matchContact({ firstName: null, lastName: null, email: "JANE@example.com" }, contacts);
+    expect(match?.id).toBe("c1");
+  });
+
+  it("falls back to a full name match when there is no email", () => {
+    const match = matchContact({ firstName: "Jane", lastName: "Doe", email: null }, contacts);
+    expect(match?.id).toBe("c1");
+  });
+
+  it("refuses to guess when a name is ambiguous", () => {
+    expect(matchContact({ firstName: "Bob", lastName: "Smith", email: null }, contacts)).toBeNull();
+  });
+
+  it("does not match on a first name alone", () => {
+    expect(matchContact({ firstName: "Jane", lastName: null, email: null }, contacts)).toBeNull();
+  });
+});
+
+describe("findDuplicateTransaction", () => {
+  const existing = [{ id: "t1", date: new Date("2026-03-04T00:00:00Z"), amountInCents: 5000, contactId: "c1" }];
+
+  it("flags same day, same amount, same contact", () => {
+    const dup = findDuplicateTransaction({ date: "2026-03-04", amountInCents: 5000 }, "c1", existing);
+    expect(dup?.id).toBe("t1");
+  });
+
+  it("does not flag a different contact, amount, or day", () => {
+    expect(findDuplicateTransaction({ date: "2026-03-04", amountInCents: 5000 }, "c2", existing)).toBeNull();
+    expect(findDuplicateTransaction({ date: "2026-03-04", amountInCents: 7500 }, "c1", existing)).toBeNull();
+    expect(findDuplicateTransaction({ date: "2026-03-05", amountInCents: 5000 }, "c1", existing)).toBeNull();
+  });
+});
+
+describe("matchPaymentMethod", () => {
+  it("maps the values Tithe.ly exports", () => {
+    expect(matchPaymentMethod("Credit Card")).toBe(TransactionItemMethod.Credit_Card);
+    expect(matchPaymentMethod("debit card")).toBe(TransactionItemMethod.Debit_Card);
+    expect(matchPaymentMethod("ACH")).toBe(TransactionItemMethod.ACH);
+    expect(matchPaymentMethod("Check")).toBe(TransactionItemMethod.Check);
+    expect(matchPaymentMethod("PayPal")).toBe(TransactionItemMethod.PayPal);
+  });
+
+  it("reads eCheck as ACH rather than a paper check", () => {
+    expect(matchPaymentMethod("eCheck")).toBe(TransactionItemMethod.ACH);
+  });
+
+  it("falls back to Tithe.ly when missing or unrecognized", () => {
+    expect(matchPaymentMethod(null)).toBe(TransactionItemMethod.Tithely);
+    expect(matchPaymentMethod("")).toBe(TransactionItemMethod.Tithely);
+    expect(matchPaymentMethod("something new")).toBe(TransactionItemMethod.Tithely);
+  });
+});
+
+describe("contactLabel", () => {
+  it("prefers a full name, then email, then Anonymous", () => {
+    expect(contactLabel({ firstName: "Jane", lastName: "Doe", email: "j@e.com" })).toBe("Jane Doe");
+    expect(contactLabel({ firstName: null, lastName: null, email: "j@e.com" })).toBe("j@e.com");
+    expect(contactLabel({ firstName: null, lastName: null, email: null })).toBe("Anonymous");
+  });
+});
+
+describe("analyzeRecords", () => {
+  const base = {
+    contacts: [{ id: "c1", firstName: "Jane", lastName: "Doe", email: "jane@example.com" }],
+    transactions: [{ id: "t1", date: "2026-03-04", amountInCents: 5000, contactId: "c1" }],
+    fundAccounts: { General: "acct-1" },
+    defaultAccountId: null,
+  };
+
+  const record = (over: Partial<ImportRecord> = {}): ImportRecord => ({
+    rowIndex: 0,
+    date: "2026-03-10",
+    amountInCents: 2500,
+    firstName: "New",
+    lastName: "Donor",
+    email: "new@example.com",
+    fund: "General",
+    paymentMethod: null,
+    note: null,
+    ...over,
+  });
+
+  it("marks a new donor as ready and flags contact creation", () => {
+    const [row] = analyzeRecords({ ...base, records: [record()] });
+    expect(row.status).toBe("ready");
+    expect(row.willCreateContact).toBe(true);
+    expect(row.accountId).toBe("acct-1");
+  });
+
+  it("reuses an existing contact without creating one", () => {
+    const [row] = analyzeRecords({ ...base, records: [record({ email: "jane@example.com" })] });
+    expect(row.matchedContactId).toBe("c1");
+    expect(row.willCreateContact).toBe(false);
+  });
+
+  it("flags a row already present in Causeway as a duplicate", () => {
+    const [row] = analyzeRecords({
+      ...base,
+      records: [record({ email: "jane@example.com", date: "2026-03-04", amountInCents: 5000 })],
+    });
+    expect(row.status).toBe("duplicate");
+    expect(row.message).toBe("Already in Causeway");
+  });
+
+  it("errors when a fund has no account chosen", () => {
+    const [row] = analyzeRecords({ ...base, records: [record({ fund: "Missions" })] });
+    expect(row.status).toBe("error");
+    expect(row.message).toContain("Missions");
+  });
+
+  it("uses the default account for records with no fund", () => {
+    const [row] = analyzeRecords({ ...base, defaultAccountId: "acct-9", records: [record({ fund: null })] });
+    expect(row.status).toBe("ready");
+    expect(row.accountId).toBe("acct-9");
+  });
+
+  it("does not create a contact for an anonymous gift", () => {
+    const [row] = analyzeRecords({
+      ...base,
+      records: [record({ firstName: null, lastName: null, email: null })],
+    });
+    expect(row.willCreateContact).toBe(false);
+    expect(row.contactLabel).toBe("Anonymous");
   });
 });

--- a/app/lib/tithely-import.ts
+++ b/app/lib/tithely-import.ts
@@ -306,7 +306,8 @@ export type RowAnalysis = {
 /** Human-readable donor label for the preview table. */
 export function contactLabel(record: Pick<ImportRecord, "firstName" | "lastName" | "email">): string {
   const name = [record.firstName, record.lastName].filter(Boolean).join(" ").trim();
-  return name || record.email || "Anonymous";
+  if (name !== "") return name;
+  return record.email ?? "Anonymous";
 }
 
 /**
@@ -332,7 +333,9 @@ export function analyzeRecords({
   return records.map((record) => {
     const matched = matchContact(record, contacts);
     const label = contactLabel(record);
-    const accountId = (record.fund ? fundAccounts[record.fund] : defaultAccountId) || null;
+    // An empty string is the "don't import rows for this fund" sentinel.
+    const chosen = record.fund ? fundAccounts[record.fund] : defaultAccountId;
+    const accountId = chosen === undefined || chosen === "" ? null : chosen;
 
     const base = {
       rowIndex: record.rowIndex,

--- a/app/lib/tithely-import.ts
+++ b/app/lib/tithely-import.ts
@@ -1,3 +1,13 @@
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import utc from "dayjs/plugin/utc";
+
+import { TransactionItemMethod } from "~/lib/constants";
+import { parseCurrencyToCents, type ParsedCsv } from "~/lib/csv";
+
+dayjs.extend(customParseFormat);
+dayjs.extend(utc);
+
 export type ImportFieldKey =
   | "date"
   | "amount"
@@ -82,4 +92,270 @@ export function autoDetectMapping(headers: Array<string>): ColumnMapping {
 /** Import fields whose required source column has not yet been mapped. */
 export function missingRequiredFields(mapping: ColumnMapping): Array<ImportField> {
   return importFields.filter((f) => f.required && (mapping[f.key] ?? UNMAPPED) === UNMAPPED);
+}
+
+/**
+ * Date formats seen in Tithe.ly exports and spreadsheet re-saves, tried in
+ * order. Parsed strictly so that "3/4/2026" isn't silently read as a time.
+ */
+const DATE_FORMATS = ["YYYY-MM-DD", "M/D/YYYY", "MM/DD/YYYY", "M-D-YYYY", "YYYY/MM/DD", "M/D/YY", "MMM D, YYYY"];
+
+/** Parse a date cell into a YYYY-MM-DD string, or null if unrecognizable. */
+export function parseImportDate(input: string | null | undefined): string | null {
+  const value = (input ?? "").trim();
+  if (!value) return null;
+
+  for (const format of DATE_FORMATS) {
+    const parsed = dayjs(value, format, true);
+    if (parsed.isValid()) return parsed.format("YYYY-MM-DD");
+  }
+
+  // Fall back to loose parsing so ISO timestamps ("2026-03-04T12:00:00Z") work.
+  const loose = dayjs(value);
+  return loose.isValid() ? loose.format("YYYY-MM-DD") : null;
+}
+
+/** One CSV row normalized into the shape the importer works with. */
+export type ImportRecord = {
+  /** Zero-based index into the CSV's data rows, used to tie back to the file. */
+  rowIndex: number;
+  date: string;
+  amountInCents: number;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+  fund: string | null;
+  paymentMethod: string | null;
+  note: string | null;
+};
+
+export type RowError = { rowIndex: number; message: string };
+
+function cell(row: Array<string>, index: number): string | null {
+  if (index === UNMAPPED) return null;
+  const value = (row[index] ?? "").trim();
+  return value === "" ? null : value;
+}
+
+/**
+ * Turn parsed CSV rows into import records using the admin's column mapping.
+ * Rows with an unusable date or amount are collected as errors rather than
+ * silently dropped, so the preview can show exactly which lines need attention.
+ */
+export function toImportRecords(parsed: ParsedCsv, mapping: ColumnMapping) {
+  const records: Array<ImportRecord> = [];
+  const errors: Array<RowError> = [];
+
+  parsed.rows.forEach((row, rowIndex) => {
+    const rawDate = cell(row, mapping.date);
+    const rawAmount = cell(row, mapping.amount);
+
+    // Skip rows that are entirely blank rather than reporting them as errors.
+    if (row.every((c) => c.trim() === "")) return;
+
+    const date = parseImportDate(rawDate);
+    if (!date) {
+      errors.push({ rowIndex, message: rawDate ? `Unrecognized date "${rawDate}"` : "Missing date" });
+      return;
+    }
+
+    const amountInCents = parseCurrencyToCents(rawAmount);
+    if (amountInCents === null) {
+      errors.push({ rowIndex, message: rawAmount ? `Unrecognized amount "${rawAmount}"` : "Missing amount" });
+      return;
+    }
+    if (amountInCents === 0) {
+      errors.push({ rowIndex, message: "Amount is $0.00" });
+      return;
+    }
+
+    records.push({
+      rowIndex,
+      date,
+      amountInCents,
+      firstName: cell(row, mapping.firstName),
+      lastName: cell(row, mapping.lastName),
+      email: cell(row, mapping.email),
+      fund: cell(row, mapping.fund),
+      paymentMethod: cell(row, mapping.paymentMethod),
+      note: cell(row, mapping.note),
+    });
+  });
+
+  return { records, errors };
+}
+
+/** The distinct fund names in a set of records, in first-seen order. */
+export function distinctFunds(records: Array<ImportRecord>): Array<string> {
+  const seen = new Set<string>();
+  const funds: Array<string> = [];
+  for (const record of records) {
+    if (record.fund && !seen.has(record.fund)) {
+      seen.add(record.fund);
+      funds.push(record.fund);
+    }
+  }
+  return funds;
+}
+
+export type ExistingContact = {
+  id: string;
+  firstName: string | null;
+  lastName: string | null;
+  email: string | null;
+};
+
+export type ExistingTransaction = {
+  id: string;
+  date: Date | string;
+  amountInCents: number;
+  contactId: string | null;
+};
+
+function nameKey(firstName: string | null, lastName: string | null): string | null {
+  const first = (firstName ?? "").trim().toLowerCase();
+  const last = (lastName ?? "").trim().toLowerCase();
+  if (!first || !last) return null;
+  return `${first} ${last}`;
+}
+
+/**
+ * Find the contact a donation row belongs to. Email is authoritative because
+ * it's unique per org; a full first+last name match is the fallback for rows
+ * where Tithe.ly has no email on file. A first name alone is never enough.
+ */
+export function matchContact(
+  record: Pick<ImportRecord, "firstName" | "lastName" | "email">,
+  contacts: Array<ExistingContact>,
+): ExistingContact | null {
+  if (record.email) {
+    const email = record.email.toLowerCase();
+    const byEmail = contacts.find((c) => c.email?.toLowerCase() === email);
+    if (byEmail) return byEmail;
+  }
+
+  const key = nameKey(record.firstName, record.lastName);
+  if (!key) return null;
+
+  const byName = contacts.filter((c) => nameKey(c.firstName, c.lastName) === key);
+  // Ambiguous name matches are left unmatched so the importer doesn't guess.
+  return byName.length === 1 ? byName[0] : null;
+}
+
+/**
+ * A row is treated as already imported when a non-voided transaction exists on
+ * the same day, for the same amount, against the same contact. Voided
+ * transactions are excluded by the caller so a corrected gift can be re-imported.
+ *
+ * Dates are compared in UTC because transactions are stored at UTC midnight
+ * (see the transaction schema); comparing in local time would shift a gift to
+ * the previous day west of UTC and let a duplicate through.
+ */
+export function findDuplicateTransaction(
+  record: Pick<ImportRecord, "date" | "amountInCents">,
+  contactId: string | null,
+  transactions: Array<ExistingTransaction>,
+): ExistingTransaction | null {
+  return (
+    transactions.find(
+      (t) =>
+        t.amountInCents === record.amountInCents &&
+        t.contactId === contactId &&
+        dayjs.utc(t.date).format("YYYY-MM-DD") === record.date,
+    ) ?? null
+  );
+}
+
+/**
+ * Map a Tithe.ly payment method string onto a Causeway transaction item method.
+ * Falls back to Tithe.ly itself when the value is missing or unrecognized, so
+ * an imported gift is never silently mislabeled.
+ */
+export function matchPaymentMethod(value: string | null | undefined): TransactionItemMethod {
+  const normalized = (value ?? "").toLowerCase().replace(/[^a-z]/g, "");
+  if (!normalized) return TransactionItemMethod.Tithely;
+
+  if (normalized.includes("paypal")) return TransactionItemMethod.PayPal;
+  if (normalized.includes("debit")) return TransactionItemMethod.Debit_Card;
+  if (normalized.includes("credit") || normalized === "card" || normalized === "cc") {
+    return TransactionItemMethod.Credit_Card;
+  }
+  if (normalized.includes("ach") || normalized.includes("bank") || normalized.includes("echeck")) {
+    return TransactionItemMethod.ACH;
+  }
+  // Checked after echeck/ach so "eCheck" isn't read as a paper check.
+  if (normalized.includes("check")) return TransactionItemMethod.Check;
+  if (normalized.includes("cash")) return TransactionItemMethod.Other;
+
+  return TransactionItemMethod.Tithely;
+}
+
+export type RowStatus = "ready" | "duplicate" | "error";
+
+export type RowAnalysis = {
+  rowIndex: number;
+  status: RowStatus;
+  /** Why a row is a duplicate or an error; null when the row is ready. */
+  message: string | null;
+  contactLabel: string;
+  matchedContactId: string | null;
+  willCreateContact: boolean;
+  accountId: string | null;
+};
+
+/** Human-readable donor label for the preview table. */
+export function contactLabel(record: Pick<ImportRecord, "firstName" | "lastName" | "email">): string {
+  const name = [record.firstName, record.lastName].filter(Boolean).join(" ").trim();
+  return name || record.email || "Anonymous";
+}
+
+/**
+ * Classify every record against the org's existing contacts and transactions.
+ * Pure so it can be unit tested; the service layer supplies the DB reads.
+ *
+ * `fundAccounts` maps a CSV fund name to an account id, and `defaultAccountId`
+ * covers records with no fund (or files with no fund column at all).
+ */
+export function analyzeRecords({
+  records,
+  contacts,
+  transactions,
+  fundAccounts,
+  defaultAccountId,
+}: {
+  records: Array<ImportRecord>;
+  contacts: Array<ExistingContact>;
+  transactions: Array<ExistingTransaction>;
+  fundAccounts: Record<string, string>;
+  defaultAccountId: string | null;
+}): Array<RowAnalysis> {
+  return records.map((record) => {
+    const matched = matchContact(record, contacts);
+    const label = contactLabel(record);
+    const accountId = (record.fund ? fundAccounts[record.fund] : defaultAccountId) || null;
+
+    const base = {
+      rowIndex: record.rowIndex,
+      contactLabel: label,
+      matchedContactId: matched?.id ?? null,
+      // Anonymous rows (no name and no email) don't get a contact created.
+      willCreateContact: !matched && Boolean(record.email ?? nameKey(record.firstName, record.lastName)),
+      accountId,
+    };
+
+    if (!accountId) {
+      return {
+        ...base,
+        status: "error" as const,
+        message: record.fund ? `No account chosen for fund "${record.fund}"` : "No account chosen",
+      };
+    }
+
+    const duplicate = findDuplicateTransaction(record, matched?.id ?? null, transactions);
+    if (duplicate) {
+      return { ...base, status: "duplicate" as const, message: "Already in Causeway" };
+    }
+
+    return { ...base, status: "ready" as const, message: null };
+  });
 }

--- a/app/routes/_app.transactions.import.tsx
+++ b/app/routes/_app.transactions.import.tsx
@@ -1,41 +1,161 @@
-import { IconFileTypeCsv, IconRefresh, IconUpload } from "@tabler/icons-react";
+import { IconAlertTriangle, IconCheck, IconCopy, IconFileTypeCsv, IconRefresh, IconUpload } from "@tabler/icons-react";
 import { useMemo, useRef, useState } from "react";
-import type { LoaderFunctionArgs } from "react-router";
+import { Link, useFetcher, useLoaderData, type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
+import { z } from "zod/v4";
 
 import { PageHeader } from "~/components/common/page-header";
 import { ErrorComponent } from "~/components/error-component";
 import { PageContainer } from "~/components/page-container";
+import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { Callout } from "~/components/ui/callout";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+import { Checkbox } from "~/components/ui/checkbox";
 import { Label } from "~/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { db } from "~/integrations/prisma.server";
 import { parseCsv, parseCurrencyToCents, type ParsedCsv } from "~/lib/csv";
+import { handleLoaderError } from "~/lib/responses.server";
+import { Toasts } from "~/lib/toast.server";
 import {
   autoDetectMapping,
+  distinctFunds,
   importFields,
   missingRequiredFields,
+  toImportRecords,
   UNMAPPED,
   type ColumnMapping,
+  type ImportRecord,
+  type RowAnalysis,
 } from "~/lib/tithely-import";
 import { cn, formatCentsAsDollars } from "~/lib/utils";
+import { DonationImportService } from "~/services.server/donation-import";
 import { SessionService } from "~/services.server/session";
 
 const PREVIEW_ROWS = 8;
+const MAX_ROWS = 5000;
+
+/** Sentinel for "don't import rows for this fund". */
+const SKIP_FUND = "";
+/** Key used for records that have no fund value (or files with no fund column). */
+const NO_FUND = "__none__";
 
 export async function loader(args: LoaderFunctionArgs) {
   await SessionService.requireAdmin(args);
-  return null;
+  const orgId = await SessionService.requireOrgId(args);
+
+  try {
+    const accounts = await db.account.findMany({
+      where: { orgId, isHidden: false },
+      select: { id: true, code: true, description: true },
+      orderBy: { code: "asc" },
+    });
+    return { accounts };
+  } catch (e) {
+    handleLoaderError(e);
+  }
 }
 
+const importRecordSchema = z.object({
+  rowIndex: z.number().int().nonnegative(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  amountInCents: z.number().int(),
+  firstName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  email: z.string().nullable(),
+  fund: z.string().nullable(),
+  paymentMethod: z.string().nullable(),
+  note: z.string().nullable(),
+});
+
+const payloadSchema = z.object({
+  records: z.array(importRecordSchema).min(1).max(MAX_ROWS),
+  fundAccounts: z.record(z.string(), z.string()),
+  defaultAccountId: z.string().nullable(),
+  selectedRowIndexes: z.array(z.number().int().nonnegative()).default([]),
+});
+
+export async function action(args: ActionFunctionArgs) {
+  await SessionService.requireAdmin(args);
+  const orgId = await SessionService.requireOrgId(args);
+
+  const formData = await args.request.formData();
+  const intent = formData.get("_action");
+
+  let payload: z.infer<typeof payloadSchema>;
+  try {
+    payload = payloadSchema.parse(JSON.parse(String(formData.get("payload") ?? "")));
+  } catch {
+    return Toasts.dataWithError(null, {
+      message: "Couldn't read that file",
+      description: "Please choose the CSV again and retry.",
+    });
+  }
+
+  const { records, fundAccounts, defaultAccountId, selectedRowIndexes } = payload;
+
+  if (intent === "analyze") {
+    const analyses = await DonationImportService.analyze({ records, fundAccounts, defaultAccountId, orgId });
+    return { analyses };
+  }
+
+  if (intent === "execute") {
+    try {
+      const summary = await DonationImportService.execute({
+        records,
+        fundAccounts,
+        defaultAccountId,
+        selectedRowIndexes,
+        orgId,
+      });
+      return Toasts.dataWithSuccess(
+        { summary },
+        {
+          message: `Imported ${summary.imported} donation${summary.imported === 1 ? "" : "s"}`,
+          description: summary.contactsCreated
+            ? `${summary.contactsCreated} new contact${summary.contactsCreated === 1 ? " was" : "s were"} created.`
+            : "No new contacts were needed.",
+        },
+      );
+    } catch {
+      return Toasts.dataWithError(null, {
+        message: "Import failed",
+        description: "Nothing was imported. Please try again or file a bug report.",
+      });
+    }
+  }
+
+  return Toasts.dataWithError(null, { message: "Unknown action" });
+}
+
+type ActionData = { analyses?: Array<RowAnalysis>; summary?: { imported: number; contactsCreated: number } } | null;
+
 export default function TransactionsImportPage() {
+  const { accounts } = useLoaderData<typeof loader>();
+  const fetcher = useFetcher<ActionData>();
+
   const [parsed, setParsed] = useState<ParsedCsv | null>(null);
   const [fileName, setFileName] = useState("");
   const [mapping, setMapping] = useState<ColumnMapping | null>(null);
+  const [fundAccounts, setFundAccounts] = useState<Record<string, string>>({});
+  const [excluded, setExcluded] = useState<Set<number>>(new Set());
   const [error, setError] = useState("");
   const [isDragging, setIsDragging] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const { records, errors } = useMemo(() => {
+    if (!parsed || !mapping) return { records: [] as Array<ImportRecord>, errors: [] };
+    return toImportRecords(parsed, mapping);
+  }, [parsed, mapping]);
+
+  const funds = useMemo(() => distinctFunds(records), [records]);
+  const hasUnfunded = useMemo(() => records.some((r) => !r.fund), [records]);
+
+  const data = fetcher.data ?? null;
+  const analyses = data?.analyses ?? null;
+  const summary = data?.summary ?? null;
+  const isBusy = fetcher.state !== "idle";
 
   async function handleFile(file: File | undefined) {
     if (!file) return;
@@ -51,6 +171,10 @@ export default function TransactionsImportPage() {
       setError("That file needs a header row and at least one row of data.");
       return;
     }
+    if (result.rows.length > MAX_ROWS) {
+      setError(`That file has ${result.rows.length} rows. Please split it into files of ${MAX_ROWS} or fewer.`);
+      return;
+    }
 
     setError("");
     setFileName(file.name);
@@ -62,16 +186,57 @@ export default function TransactionsImportPage() {
     setParsed(null);
     setFileName("");
     setMapping(null);
+    setFundAccounts({});
+    setExcluded(new Set());
     setError("");
     if (inputRef.current) inputRef.current.value = "";
+    // Clear the previous analysis/summary so the wizard returns to step one.
+    void fetcher.load(window.location.pathname);
+  }
+
+  function submit(intent: "analyze" | "execute", selectedRowIndexes: Array<number> = []) {
+    void fetcher.submit(
+      {
+        _action: intent,
+        payload: JSON.stringify({
+          records,
+          fundAccounts,
+          defaultAccountId: fundAccounts[NO_FUND] || null,
+          selectedRowIndexes,
+        }),
+      },
+      { method: "post" },
+    );
   }
 
   return (
     <>
       <title>Import Donations</title>
-      <PageHeader title="Import Donations" description="Upload a Tithe.ly giving export and match its columns to Causeway." />
+      <PageHeader
+        title="Import Donations"
+        description="Upload a Tithe.ly giving export and match its columns to Causeway."
+      />
       <PageContainer className="max-w-3xl">
-        {!parsed || !mapping ? (
+        {summary ? (
+          <ResultStep summary={summary} onReset={reset} />
+        ) : analyses ? (
+          <PreviewStep
+            analyses={analyses}
+            records={records}
+            excluded={excluded}
+            isBusy={isBusy}
+            onToggle={(rowIndex) =>
+              setExcluded((prev) => {
+                const next = new Set(prev);
+                if (next.has(rowIndex)) next.delete(rowIndex);
+                else next.add(rowIndex);
+                return next;
+              })
+            }
+            onBack={() => submit("analyze")}
+            onImport={(selectedRowIndexes) => submit("execute", selectedRowIndexes)}
+          />
+        ) : !parsed || !mapping ? (
           <UploadStep
             error={error}
             isDragging={isDragging}
@@ -80,7 +245,22 @@ export default function TransactionsImportPage() {
             onFile={handleFile}
           />
         ) : (
-          <MapStep parsed={parsed} mapping={mapping} fileName={fileName} onMappingChange={setMapping} onReset={reset} />
+          <MapStep
+            parsed={parsed}
+            mapping={mapping}
+            fileName={fileName}
+            accounts={accounts}
+            funds={funds}
+            hasUnfunded={hasUnfunded}
+            fundAccounts={fundAccounts}
+            recordCount={records.length}
+            rowErrors={errors}
+            isBusy={isBusy}
+            onMappingChange={setMapping}
+            onFundAccountChange={(fund, accountId) => setFundAccounts((prev) => ({ ...prev, [fund]: accountId }))}
+            onReset={reset}
+            onContinue={() => submit("analyze")}
+          />
         )}
       </PageContainer>
     </>
@@ -141,22 +321,47 @@ function UploadStep({
   );
 }
 
+type AccountOption = { id: string; code: string; description: string };
+
 function MapStep({
   parsed,
   mapping,
   fileName,
+  accounts,
+  funds,
+  hasUnfunded,
+  fundAccounts,
+  recordCount,
+  rowErrors,
+  isBusy,
   onMappingChange,
+  onFundAccountChange,
   onReset,
+  onContinue,
 }: {
   parsed: ParsedCsv;
   mapping: ColumnMapping;
   fileName: string;
+  accounts: Array<AccountOption>;
+  funds: Array<string>;
+  hasUnfunded: boolean;
+  fundAccounts: Record<string, string>;
+  recordCount: number;
+  rowErrors: Array<{ rowIndex: number; message: string }>;
+  isBusy: boolean;
   onMappingChange: (mapping: ColumnMapping) => void;
+  onFundAccountChange: (fund: string, accountId: string) => void;
   onReset: () => void;
+  onContinue: () => void;
 }) {
   const missing = useMemo(() => missingRequiredFields(mapping), [mapping]);
   const mappedFields = useMemo(() => importFields.filter((f) => mapping[f.key] !== UNMAPPED), [mapping]);
   const previewRows = useMemo(() => parsed.rows.slice(0, PREVIEW_ROWS), [parsed.rows]);
+
+  // Every fund in the file needs an account before the rows can be classified.
+  const fundKeys = [...funds, ...(hasUnfunded || funds.length === 0 ? [NO_FUND] : [])];
+  const unassignedFunds = fundKeys.filter((key) => fundAccounts[key] === undefined);
+  const canContinue = missing.length === 0 && recordCount > 0 && unassignedFunds.length === 0 && !isBusy;
 
   return (
     <div className="space-y-6">
@@ -219,6 +424,51 @@ function MapStep({
           Map a column for {missing.map((f) => f.label).join(" and ")} to continue. These are needed to create a
           transaction.
         </Callout>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Choose accounts</CardTitle>
+            <CardDescription>
+              {funds.length > 0
+                ? "Send each fund in your file to a Causeway account."
+                : "Your file has no fund column, so every donation goes to one account."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {fundKeys.map((key) => (
+              <div key={key} className="grid grid-cols-1 items-center gap-1.5 sm:grid-cols-[220px_1fr] sm:gap-4">
+                <Label htmlFor={`fund-${key}`} className="truncate text-sm">
+                  {key === NO_FUND ? (funds.length > 0 ? "Rows with no fund" : "All donations") : key}
+                </Label>
+                <Select
+                  value={fundAccounts[key] ?? undefined}
+                  onValueChange={(value) => onFundAccountChange(key, value)}
+                >
+                  <SelectTrigger id={`fund-${key}`} aria-label={key === NO_FUND ? "Account" : `Account for ${key}`}>
+                    <SelectValue placeholder="Choose an account" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={SKIP_FUND}>
+                      <span className="text-muted-foreground">Don&apos;t import these rows</span>
+                    </SelectItem>
+                    {accounts.map((account) => (
+                      <SelectItem key={account.id} value={account.id}>
+                        {account.code} — {account.description}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {rowErrors.length > 0 ? (
+        <Callout variant="warning">
+          {rowErrors.length} row{rowErrors.length === 1 ? "" : "s"} will be skipped because the date or amount
+          couldn&apos;t be read — for example row {rowErrors[0].rowIndex + 2}: {rowErrors[0].message}.
+        </Callout>
       ) : null}
 
       <div>
@@ -251,7 +501,202 @@ function MapStep({
           </Table>
         </div>
       </div>
+
+      <div className="flex justify-end">
+        <Button onClick={onContinue} disabled={!canContinue}>
+          {isBusy ? "Checking…" : `Check ${recordCount} donation${recordCount === 1 ? "" : "s"}`}
+        </Button>
+      </div>
     </div>
+  );
+}
+
+function PreviewStep({
+  analyses,
+  records,
+  excluded,
+  isBusy,
+  onToggle,
+  onBack,
+  onImport,
+}: {
+  analyses: Array<RowAnalysis>;
+  records: Array<ImportRecord>;
+  excluded: Set<number>;
+  isBusy: boolean;
+  onToggle: (rowIndex: number) => void;
+  onBack: () => void;
+  onImport: (selectedRowIndexes: Array<number>) => void;
+}) {
+  const recordByRow = useMemo(() => new Map(records.map((r) => [r.rowIndex, r])), [records]);
+
+  const readyRows = analyses.filter((a) => a.status === "ready");
+  const selected = readyRows.filter((a) => !excluded.has(a.rowIndex));
+  const duplicates = analyses.filter((a) => a.status === "duplicate");
+  const errored = analyses.filter((a) => a.status === "error");
+  const newContacts = new Set(selected.filter((a) => a.willCreateContact).map((a) => a.contactLabel)).size;
+  const totalCents = selected.reduce((sum, a) => sum + (recordByRow.get(a.rowIndex)?.amountInCents ?? 0), 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Stat label="To import" value={String(selected.length)} />
+        <Stat label="Total" value={formatCentsAsDollars(totalCents)} />
+        <Stat label="Already in Causeway" value={String(duplicates.length)} />
+        <Stat label="New contacts" value={String(newContacts)} />
+      </div>
+
+      {duplicates.length > 0 ? (
+        <Callout variant="info">
+          {duplicates.length} donation{duplicates.length === 1 ? "" : "s"} already exist in Causeway (same donor, date,
+          and amount) and won&apos;t be imported again.
+        </Callout>
+      ) : null}
+
+      {errored.length > 0 ? (
+        <Callout variant="warning">
+          {errored.length} row{errored.length === 1 ? "" : "s"} can&apos;t be imported yet. Go back and choose an
+          account for every fund.
+        </Callout>
+      ) : null}
+
+      <div>
+        <h2 className="mb-2 text-sm font-medium">Review donations</h2>
+        <p className="text-muted-foreground mb-3 text-xs">
+          Uncheck anything you don&apos;t want to import. Row numbers match your spreadsheet.
+        </p>
+        <div className="max-h-[28rem] overflow-auto rounded-md border">
+          <Table>
+            <TableHeader className="bg-background sticky top-0 z-10">
+              <TableRow>
+                <TableHead className="w-10" />
+                <TableHead className="w-14">Row</TableHead>
+                <TableHead>Donor</TableHead>
+                <TableHead>Date</TableHead>
+                <TableHead className="text-right">Amount</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {analyses.map((analysis) => {
+                const record = recordByRow.get(analysis.rowIndex);
+                const isReady = analysis.status === "ready";
+                const isChecked = isReady && !excluded.has(analysis.rowIndex);
+                return (
+                  <TableRow key={analysis.rowIndex} className={cn(!isReady && "opacity-60")}>
+                    <TableCell>
+                      <Checkbox
+                        checked={isChecked}
+                        disabled={!isReady}
+                        onCheckedChange={() => onToggle(analysis.rowIndex)}
+                        aria-label={`Import row ${analysis.rowIndex + 2}`}
+                      />
+                    </TableCell>
+                    <TableCell className="text-muted-foreground tabular-nums">{analysis.rowIndex + 2}</TableCell>
+                    <TableCell>
+                      <span className="flex items-center gap-1.5">
+                        <span className="truncate">{analysis.contactLabel}</span>
+                        {analysis.willCreateContact ? (
+                          <Badge variant="outline" className="shrink-0 text-xs">
+                            New
+                          </Badge>
+                        ) : null}
+                      </span>
+                    </TableCell>
+                    <TableCell className="whitespace-nowrap tabular-nums">{record?.date}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatCentsAsDollars(record?.amountInCents ?? 0)}
+                    </TableCell>
+                    <TableCell>
+                      <StatusCell analysis={analysis} />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button variant="outline" onClick={onBack} disabled={isBusy}>
+          Back
+        </Button>
+        <Button onClick={() => onImport(selected.map((a) => a.rowIndex))} disabled={isBusy || selected.length === 0}>
+          {isBusy ? "Importing…" : `Import ${selected.length} donation${selected.length === 1 ? "" : "s"}`}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function StatusCell({ analysis }: { analysis: RowAnalysis }) {
+  if (analysis.status === "duplicate") {
+    return (
+      <span className="text-muted-foreground flex items-center gap-1 text-xs">
+        <IconCopy className="size-3.5 shrink-0" aria-hidden="true" />
+        {analysis.message}
+      </span>
+    );
+  }
+  if (analysis.status === "error") {
+    return (
+      <span className="text-warning flex items-center gap-1 text-xs">
+        <IconAlertTriangle className="size-3.5 shrink-0" aria-hidden="true" />
+        {analysis.message}
+      </span>
+    );
+  }
+  return (
+    <span className="text-success flex items-center gap-1 text-xs">
+      <IconCheck className="size-3.5 shrink-0" aria-hidden="true" />
+      Ready
+    </span>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border p-3">
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <p className="text-lg font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function ResultStep({
+  summary,
+  onReset,
+}: {
+  summary: { imported: number; contactsCreated: number };
+  onReset: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <IconCheck className="text-success size-5" aria-hidden="true" />
+          Import complete
+        </CardTitle>
+        <CardDescription>
+          {summary.imported} donation{summary.imported === 1 ? "" : "s"} imported
+          {summary.contactsCreated > 0
+            ? `, and ${summary.contactsCreated} new contact${summary.contactsCreated === 1 ? "" : "s"} created`
+            : ""}
+          .
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-wrap gap-2">
+        <Button asChild>
+          <Link to="/transactions" prefetch="intent">
+            View transactions
+          </Link>
+        </Button>
+        <Button variant="outline" onClick={onReset}>
+          Import another file
+        </Button>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/app/routes/_app.transactions.import.tsx
+++ b/app/routes/_app.transactions.import.tsx
@@ -17,7 +17,6 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "~
 import { db } from "~/integrations/prisma.server";
 import { parseCsv, parseCurrencyToCents, type ParsedCsv } from "~/lib/csv";
 import { handleLoaderError } from "~/lib/responses.server";
-import { Toasts } from "~/lib/toast.server";
 import {
   autoDetectMapping,
   distinctFunds,
@@ -29,6 +28,7 @@ import {
   type ImportRecord,
   type RowAnalysis,
 } from "~/lib/tithely-import";
+import { Toasts } from "~/lib/toast.server";
 import { cn, formatCentsAsDollars } from "~/lib/utils";
 import { DonationImportService } from "~/services.server/donation-import";
 import { SessionService } from "~/services.server/session";
@@ -83,9 +83,11 @@ export async function action(args: ActionFunctionArgs) {
   const formData = await args.request.formData();
   const intent = formData.get("_action");
 
+  const rawPayload = formData.get("payload");
+
   let payload: z.infer<typeof payloadSchema>;
   try {
-    payload = payloadSchema.parse(JSON.parse(String(formData.get("payload") ?? "")));
+    payload = payloadSchema.parse(JSON.parse(typeof rawPayload === "string" ? rawPayload : ""));
   } catch {
     return Toasts.dataWithError(null, {
       message: "Couldn't read that file",
@@ -360,7 +362,7 @@ function MapStep({
 
   // Every fund in the file needs an account before the rows can be classified.
   const fundKeys = [...funds, ...(hasUnfunded || funds.length === 0 ? [NO_FUND] : [])];
-  const unassignedFunds = fundKeys.filter((key) => fundAccounts[key] === undefined);
+  const unassignedFunds = fundKeys.filter((key) => !Object.hasOwn(fundAccounts, key));
   const canContinue = missing.length === 0 && recordCount > 0 && unassignedFunds.length === 0 && !isBusy;
 
   return (

--- a/app/services.server/donation-import.ts
+++ b/app/services.server/donation-import.ts
@@ -1,0 +1,163 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+import { createLogger } from "~/integrations/logger.server";
+import { db } from "~/integrations/prisma.server";
+import { ContactType, TransactionCategory, TransactionItemType } from "~/lib/constants";
+import {
+  analyzeRecords,
+  matchContact,
+  matchPaymentMethod,
+  type ImportRecord,
+  type RowAnalysis,
+} from "~/lib/tithely-import";
+
+dayjs.extend(utc);
+
+const logger = createLogger("DonationImportService");
+
+type AnalyzeArgs = {
+  records: Array<ImportRecord>;
+  fundAccounts: Record<string, string>;
+  defaultAccountId: string | null;
+  orgId: string;
+};
+
+export type ImportSummary = {
+  imported: number;
+  contactsCreated: number;
+  skipped: number;
+};
+
+export const DonationImportService = {
+  /**
+   * Classify every record against the org's current data. Contacts are loaded
+   * in full (orgs here have hundreds, not millions) and existing transactions
+   * are narrowed to the date range covered by the file.
+   */
+  async analyze({ records, fundAccounts, defaultAccountId, orgId }: AnalyzeArgs): Promise<Array<RowAnalysis>> {
+    if (records.length === 0) return [];
+
+    // UTC to match how transaction dates are stored (see the transaction schema).
+    const dates = records.map((r) => r.date).sort();
+    const from = dayjs.utc(dates[0]).startOf("day").toDate();
+    const to = dayjs
+      .utc(dates[dates.length - 1])
+      .endOf("day")
+      .toDate();
+
+    const [contacts, transactions] = await Promise.all([
+      db.contact.findMany({
+        where: { orgId },
+        select: { id: true, firstName: true, lastName: true, email: true },
+      }),
+      // Voided transactions are excluded so a corrected gift can be re-imported.
+      db.transaction.findMany({
+        where: { orgId, voidedAt: null, date: { gte: from, lte: to } },
+        select: { id: true, date: true, amountInCents: true, contactId: true },
+      }),
+    ]);
+
+    return analyzeRecords({ records, contacts, transactions, fundAccounts, defaultAccountId });
+  },
+
+  /**
+   * Import the selected rows. The analysis is re-run server-side rather than
+   * trusted from the client, so a row that became a duplicate since the preview
+   * — or that points at an account outside this org — is never written.
+   */
+  async execute({
+    records,
+    fundAccounts,
+    defaultAccountId,
+    selectedRowIndexes,
+    orgId,
+  }: AnalyzeArgs & { selectedRowIndexes: Array<number> }): Promise<ImportSummary> {
+    const analyses = await this.analyze({ records, fundAccounts, defaultAccountId, orgId });
+    const analysisByRow = new Map(analyses.map((a) => [a.rowIndex, a]));
+    const selected = new Set(selectedRowIndexes);
+
+    const toImport = records.filter((record) => {
+      const analysis = analysisByRow.get(record.rowIndex);
+      return selected.has(record.rowIndex) && analysis?.status === "ready";
+    });
+
+    if (toImport.length === 0) {
+      return { imported: 0, contactsCreated: 0, skipped: selectedRowIndexes.length };
+    }
+
+    // Confirm every target account belongs to this org before writing anything.
+    const accountIds = [...new Set(toImport.map((r) => analysisByRow.get(r.rowIndex)!.accountId!))];
+    const ownedAccounts = await db.account.findMany({
+      where: { id: { in: accountIds }, orgId },
+      select: { id: true },
+    });
+    if (ownedAccounts.length !== accountIds.length) {
+      throw new Error("One or more selected accounts do not belong to this organization.");
+    }
+
+    let contactsCreated = 0;
+
+    await db.$transaction(async (tx) => {
+      // Contacts created during this import, so two rows for the same new donor
+      // share one contact instead of colliding on the unique email constraint.
+      const created: Array<{ id: string; firstName: string | null; lastName: string | null; email: string | null }> =
+        [];
+
+      for (const record of toImport) {
+        const analysis = analysisByRow.get(record.rowIndex)!;
+        let contactId = analysis.matchedContactId;
+
+        if (!contactId && analysis.willCreateContact) {
+          const alreadyCreated = matchContact(record, created);
+          if (alreadyCreated) {
+            contactId = alreadyCreated.id;
+          } else {
+            const contact = await tx.contact.create({
+              data: {
+                orgId,
+                typeId: ContactType.Donor,
+                firstName: record.firstName,
+                lastName: record.lastName,
+                email: record.email,
+              },
+              select: { id: true, firstName: true, lastName: true, email: true },
+            });
+            created.push(contact);
+            contactId = contact.id;
+            contactsCreated++;
+          }
+        }
+
+        await tx.transaction.create({
+          data: {
+            orgId,
+            accountId: analysis.accountId!,
+            contactId,
+            date: dayjs.utc(record.date).startOf("day").toDate(),
+            amountInCents: record.amountInCents,
+            categoryId: TransactionCategory.Donation_Standard,
+            description: record.note,
+            transactionItems: {
+              create: {
+                orgId,
+                amountInCents: record.amountInCents,
+                typeId: TransactionItemType.Donation,
+                methodId: matchPaymentMethod(record.paymentMethod),
+                description: record.note,
+              },
+            },
+          },
+        });
+      }
+    });
+
+    const summary: ImportSummary = {
+      imported: toImport.length,
+      contactsCreated,
+      skipped: selectedRowIndexes.length - toImport.length,
+    };
+    logger.info("Donation import complete", { orgId, ...summary });
+    return summary;
+  },
+};


### PR DESCRIPTION
Completes the Tithe.ly import started in PR 6. PR 6 ended with columns mapped; this turns that mapping into transactions.

## What it does
1. **Choose accounts** — each fund in the CSV is matched to a Causeway account (or excluded). Files with no fund column pick one account for everything.
2. **Preview** — every row is classified before anything is written:
   - **Ready** — will be imported
   - **Already in Causeway** — a non-voided transaction exists with the same donor, date, and amount
   - **Error** — no account chosen for that fund

   Rows can be individually unchecked. Donors who don't exist yet are badged **New**.
3. **Import** — selected rows are written in a single transaction, creating donor contacts as needed.

## Matching rules
- **Donor** — matched by email first (it's unique per org), then by an unambiguous full name. A first name alone never matches, and an ambiguous full name is left unmatched rather than guessed.
- **Duplicates** — same donor + same day + same amount. Voided transactions are ignored, so a corrected gift can be re-imported.
- **Payment method** — mapped from the CSV (`Check`, `ACH`, `Credit Card`…), falling back to Tithe.ly. `eCheck` is read as ACH, not a paper check.

## Notes for review
- Dates are compared and written in **UTC** to match `app/schemas/index.ts`, which stores transaction dates at UTC midnight. Comparing in local time silently shifted gifts a day earlier west of UTC and let duplicates through — there's a regression test for this.
- The analysis is **re-run server-side on import** rather than trusted from the client, so a row that became a duplicate since the preview, or an account belonging to another org, is never written.
- Matching logic is pure and lives in `app/lib/tithely-import.ts` with 27 unit tests; `app/services.server/donation-import.ts` only does the DB reads and the write.
- No schema change and no new dependencies.

## Test plan
- [ ] Import a Tithe.ly export → transactions appear against the right accounts
- [ ] Import the same file twice → every row on the second pass reads "Already in Causeway"
- [ ] A gift from a new donor creates one contact; two gifts from the same new donor create only one
- [ ] Void an imported transaction, re-import → that row is offered again
- [ ] Leave a fund unassigned → those rows show as errors and can't be imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)