### PR TITLE
PR 10: Multi-line expense report builder

### DIFF
--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -8,6 +8,7 @@ import {
   IconCreditCardRefund,
   IconFileImport,
   IconFileSpreadsheet,
+  IconReceipt2,
   IconScale,
   IconTransfer,
   IconUserHeart,
@@ -196,6 +197,7 @@ export const globalNavLinks: ReadonlyArray<AppNavLink> = [
   { name: "Contacts", to: "/contacts", end: false, prefetch: false, icon: IconUsers },
   { name: "Engagements", to: "/engagements", end: true, prefetch: false, icon: IconUserHeart },
   { name: "Reimbursement", to: "/reimbursements/new", end: false, prefetch: true, icon: IconCoin },
+  { name: "Expense Report", to: "/expense-reports/new", end: false, prefetch: true, icon: IconReceipt2 },
 ] as const;
 
 export const userNavLinks: ReadonlyArray<AppNavLink> = [] as const;

--- a/app/lib/expense-report.test.ts
+++ b/app/lib/expense-report.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isSubmittable,
+  lineProblems,
+  reportProblems,
+  reportTotalInCents,
+  subtotalsByAccount,
+  type ExpenseLine,
+} from "~/lib/expense-report";
+
+function line(over: Partial<ExpenseLine> = {}): ExpenseLine {
+  return {
+    key: "k1",
+    date: "2026-07-10",
+    vendor: "Office Depot",
+    description: "Printer paper",
+    amountInCents: 2500,
+    accountId: "acct-1",
+    methodId: 4,
+    receiptIds: [],
+    ...over,
+  };
+}
+
+describe("reportTotalInCents", () => {
+  it("sums every line", () => {
+    expect(reportTotalInCents([line({ amountInCents: 2500 }), line({ amountInCents: 7500 })])).toBe(10000);
+  });
+
+  it("is zero for an empty report", () => {
+    expect(reportTotalInCents([])).toBe(0);
+  });
+});
+
+describe("subtotalsByAccount", () => {
+  it("groups amounts per account in first-seen order", () => {
+    const lines = [
+      line({ key: "a", accountId: "acct-1", amountInCents: 1000 }),
+      line({ key: "b", accountId: "acct-2", amountInCents: 2000 }),
+      line({ key: "c", accountId: "acct-1", amountInCents: 500 }),
+    ];
+
+    expect(subtotalsByAccount(lines)).toEqual([
+      { accountId: "acct-1", count: 2, totalInCents: 1500 },
+      { accountId: "acct-2", count: 1, totalInCents: 2000 },
+    ]);
+  });
+
+  it("skips lines with no account chosen yet", () => {
+    expect(subtotalsByAccount([line({ accountId: "" })])).toEqual([]);
+  });
+});
+
+describe("lineProblems", () => {
+  it("passes a complete line", () => {
+    expect(lineProblems(line())).toEqual([]);
+  });
+
+  it("flags a missing or malformed date", () => {
+    expect(lineProblems(line({ date: "" }))).toContain("Choose a date");
+    expect(lineProblems(line({ date: "07/10/2026" }))).toContain("Choose a date");
+  });
+
+  it("flags a non-positive amount", () => {
+    expect(lineProblems(line({ amountInCents: 0 }))).toContain("Enter an amount over $0.00");
+    expect(lineProblems(line({ amountInCents: -100 }))).toContain("Enter an amount over $0.00");
+  });
+
+  it("flags a missing account or method", () => {
+    expect(lineProblems(line({ accountId: "" }))).toContain("Choose an account");
+    expect(lineProblems(line({ methodId: null }))).toContain("Choose a payment method");
+  });
+});
+
+describe("reportProblems", () => {
+  it("collects problems keyed to each line", () => {
+    const problems = reportProblems([line({ key: "good" }), line({ key: "bad", amountInCents: 0, accountId: "" })]);
+    expect(problems.every((p) => p.key === "bad")).toBe(true);
+    expect(problems).toHaveLength(2);
+  });
+});
+
+describe("isSubmittable", () => {
+  it("requires at least one line", () => {
+    expect(isSubmittable([])).toBe(false);
+  });
+
+  it("is false while any line has a problem", () => {
+    expect(isSubmittable([line(), line({ amountInCents: 0 })])).toBe(false);
+  });
+
+  it("is true when every line is complete", () => {
+    expect(isSubmittable([line({ key: "a" }), line({ key: "b" })])).toBe(true);
+  });
+});

--- a/app/lib/expense-report.ts
+++ b/app/lib/expense-report.ts
@@ -1,0 +1,70 @@
+/**
+ * A single line in an expense report. Mirrors the fields of a reimbursement
+ * request, since submitting a report creates one request per line — category is
+ * deliberately absent because an admin assigns it at approval time.
+ */
+export type ExpenseLine = {
+  /** Stable client-side id so React keys and edits survive reordering. */
+  key: string;
+  date: string;
+  vendor: string;
+  description: string;
+  amountInCents: number;
+  accountId: string;
+  methodId: number | null;
+  receiptIds: Array<string>;
+};
+
+export type LineProblem = { key: string; message: string };
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Grand total of every line, in cents. */
+export function reportTotalInCents(lines: Array<ExpenseLine>): number {
+  return lines.reduce((total, line) => total + line.amountInCents, 0);
+}
+
+export type AccountSubtotal = { accountId: string; count: number; totalInCents: number };
+
+/**
+ * Subtotals per account, in first-seen order. An expense report often draws
+ * from more than one fund, and each fund's admin needs its own total.
+ */
+export function subtotalsByAccount(lines: Array<ExpenseLine>): Array<AccountSubtotal> {
+  const order: Array<string> = [];
+  const byAccount = new Map<string, AccountSubtotal>();
+
+  for (const line of lines) {
+    if (!line.accountId) continue;
+    let entry = byAccount.get(line.accountId);
+    if (!entry) {
+      entry = { accountId: line.accountId, count: 0, totalInCents: 0 };
+      byAccount.set(line.accountId, entry);
+      order.push(line.accountId);
+    }
+    entry.count += 1;
+    entry.totalInCents += line.amountInCents;
+  }
+
+  return order.map((id) => byAccount.get(id)!);
+}
+
+/** Everything wrong with one line, as reader-facing messages. */
+export function lineProblems(line: ExpenseLine): Array<string> {
+  const problems: Array<string> = [];
+  if (!ISO_DATE.test(line.date)) problems.push("Choose a date");
+  if (!Number.isInteger(line.amountInCents) || line.amountInCents <= 0) problems.push("Enter an amount over $0.00");
+  if (!line.accountId) problems.push("Choose an account");
+  if (line.methodId === null) problems.push("Choose a payment method");
+  return problems;
+}
+
+/** Per-line problems across the whole report, keyed to each line. */
+export function reportProblems(lines: Array<ExpenseLine>): Array<LineProblem> {
+  return lines.flatMap((line) => lineProblems(line).map((message) => ({ key: line.key, message })));
+}
+
+/** A report is submittable when it has at least one line and no line problems. */
+export function isSubmittable(lines: Array<ExpenseLine>): boolean {
+  return lines.length > 0 && reportProblems(lines).length === 0;
+}

--- a/app/routes/_app.expense-reports.new.tsx
+++ b/app/routes/_app.expense-reports.new.tsx
@@ -1,0 +1,432 @@
+import { render } from "@react-email/render";
+import { IconPaperclip, IconPlus, IconTrash } from "@tabler/icons-react";
+import { useState } from "react";
+import { Form, useActionData, useLoaderData, type ActionFunctionArgs, type LoaderFunctionArgs } from "react-router";
+import { z } from "zod/v4";
+
+import { ReimbursementRequestEmail } from "emails/reimbursement-request";
+import { PageHeader } from "~/components/common/page-header";
+import { ErrorComponent } from "~/components/error-component";
+import { PageContainer } from "~/components/page-container";
+import { Button } from "~/components/ui/button";
+import { Callout } from "~/components/ui/callout";
+import { Card, CardContent } from "~/components/ui/card";
+import { Checkbox } from "~/components/ui/checkbox";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "~/components/ui/select";
+import { Textarea } from "~/components/ui/textarea";
+import { Mailer } from "~/integrations/email.server";
+import { createLogger } from "~/integrations/logger.server";
+import { db } from "~/integrations/prisma.server";
+import { Sentry } from "~/integrations/sentry";
+import { CONFIG } from "~/lib/env.server";
+import {
+  isSubmittable,
+  lineProblems,
+  reportTotalInCents,
+  subtotalsByAccount,
+  type ExpenseLine,
+} from "~/lib/expense-report";
+import { Toasts } from "~/lib/toast.server";
+import { formatCentsAsDollars, getToday } from "~/lib/utils";
+import { ExpenseReportService } from "~/services.server/expense-report";
+import { SessionService } from "~/services.server/session";
+import { TransactionService } from "~/services.server/transaction";
+
+const logger = createLogger("Routes.ExpenseReportsNew");
+
+const MAX_LINES = 100;
+
+export async function loader(args: LoaderFunctionArgs) {
+  const user = await SessionService.requireUser(args);
+  const orgId = await SessionService.requireOrgId(args);
+
+  const [accounts, methods, receipts] = await db.$transaction([
+    db.account.findMany({
+      where: { orgId, user: user.isMember ? { id: user.id } : undefined },
+      select: { id: true, code: true, description: true },
+      orderBy: { code: "asc" },
+    }),
+    TransactionService.getItemMethods(orgId),
+    db.receipt.findMany({
+      where: { orgId, userId: user.isMember ? user.id : undefined },
+      select: { id: true, title: true },
+      orderBy: { createdAt: "desc" },
+    }),
+  ]);
+
+  return { accounts, methods, receipts };
+}
+
+const lineSchema = z.object({
+  key: z.string(),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  vendor: z.string().max(255),
+  description: z.string().max(1000),
+  amountInCents: z.number().int().positive(),
+  accountId: z.string().min(1),
+  methodId: z.number().int(),
+  receiptIds: z.array(z.string()),
+});
+
+const payloadSchema = z.object({ lines: z.array(lineSchema).min(1).max(MAX_LINES) });
+
+export async function action(args: ActionFunctionArgs) {
+  const user = await SessionService.requireUser(args);
+  const orgId = await SessionService.requireOrgId(args);
+
+  let lines: Array<ExpenseLine>;
+  try {
+    const raw = (await args.request.formData()).get("payload");
+    lines = payloadSchema.parse(JSON.parse(typeof raw === "string" ? raw : "")).lines;
+  } catch {
+    return { error: "Your report couldn't be read. Please review the lines and try again." };
+  }
+
+  try {
+    const summary = await ExpenseReportService.submit({ lines, userId: user.id, orgId });
+
+    // One summary email to the org, rather than one per line.
+    const org = await db.organization.findUnique({ where: { id: orgId }, select: { primaryEmail: true } });
+    if (org?.primaryEmail) {
+      await Mailer.send({
+        to: org.primaryEmail,
+        subject: "New Expense Report",
+        html: await render(
+          <ReimbursementRequestEmail
+            url={CONFIG.baseUrl}
+            accountName={`${summary.created}-line expense report`}
+            amountInCents={summary.totalInCents}
+            requesterName={`${user.contact.firstName ?? ""} ${user.contact.lastName ?? ""}`.trim() || user.username}
+          />,
+        ),
+      });
+    }
+
+    return Toasts.redirectWithSuccess(`/dashboards/${user.isMember ? "staff" : "admin"}`, {
+      message: `Expense report submitted`,
+      description: `${summary.created} line${summary.created === 1 ? "" : "s"} totaling ${formatCentsAsDollars(summary.totalInCents)} sent for review.`,
+    });
+  } catch (error) {
+    logger.error("Error submitting expense report", { error });
+    Sentry.captureException(error);
+    return { error: error instanceof Error ? error.message : "An unknown error occurred." };
+  }
+}
+
+type LoaderData = Awaited<ReturnType<typeof loader>>;
+
+function newLine(): ExpenseLine {
+  return {
+    key: crypto.randomUUID(),
+    date: getToday(),
+    vendor: "",
+    description: "",
+    amountInCents: 0,
+    accountId: "",
+    methodId: null,
+    receiptIds: [],
+  };
+}
+
+export default function NewExpenseReportPage() {
+  const { accounts, methods, receipts } = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const serverError = actionData && "error" in actionData ? actionData.error : undefined;
+
+  const [lines, setLines] = useState<Array<ExpenseLine>>([newLine()]);
+
+  function updateLine(key: string, patch: Partial<ExpenseLine>) {
+    setLines((prev) => prev.map((line) => (line.key === key ? { ...line, ...patch } : line)));
+  }
+  function removeLine(key: string) {
+    setLines((prev) => prev.filter((line) => line.key !== key));
+  }
+
+  const total = reportTotalInCents(lines);
+  const subtotals = subtotalsByAccount(lines);
+  const canSubmit = isSubmittable(lines);
+  const accountLabel = (id: string) => {
+    const account = accounts.find((a) => a.id === id);
+    return account ? `${account.code} — ${account.description}` : id;
+  };
+
+  return (
+    <>
+      <title>New Expense Report</title>
+      <PageHeader
+        title="New Expense Report"
+        description="Itemize several expenses and submit them for reimbursement in one report."
+      />
+      <PageContainer className="max-w-3xl">
+        <Form method="post" className="space-y-6">
+          {serverError ? (
+            <Callout variant="destructive" role="alert">
+              {serverError}
+            </Callout>
+          ) : null}
+
+          <ol className="space-y-3">
+            {lines.map((line, index) => (
+              <li key={line.key}>
+                <ExpenseLineCard
+                  line={line}
+                  index={index}
+                  accounts={accounts}
+                  methods={methods}
+                  receipts={receipts}
+                  canRemove={lines.length > 1}
+                  onChange={(patch) => updateLine(line.key, patch)}
+                  onRemove={() => removeLine(line.key)}
+                />
+              </li>
+            ))}
+          </ol>
+
+          <Button type="button" variant="outline" onClick={() => setLines((prev) => [...prev, newLine()])}>
+            <IconPlus className="mr-2 size-4" aria-hidden="true" />
+            Add expense
+          </Button>
+
+          <div className="rounded-lg border p-4">
+            <div className="flex items-baseline justify-between">
+              <span className="text-sm font-medium">Report total</span>
+              <span className="text-lg font-semibold tabular-nums">{formatCentsAsDollars(total)}</span>
+            </div>
+            {subtotals.length > 1 ? (
+              <dl className="mt-3 space-y-1 border-t pt-3">
+                {subtotals.map((s) => (
+                  <div key={s.accountId} className="flex justify-between text-sm">
+                    <dt className="text-muted-foreground truncate">
+                      {accountLabel(s.accountId)}
+                      <span className="ml-1">
+                        ({s.count} line{s.count === 1 ? "" : "s"})
+                      </span>
+                    </dt>
+                    <dd className="tabular-nums">{formatCentsAsDollars(s.totalInCents)}</dd>
+                  </div>
+                ))}
+              </dl>
+            ) : null}
+          </div>
+
+          <input type="hidden" name="payload" value={JSON.stringify({ lines })} />
+
+          <div className="flex justify-end">
+            <Button type="submit" disabled={!canSubmit}>
+              Submit report
+            </Button>
+          </div>
+        </Form>
+      </PageContainer>
+    </>
+  );
+}
+
+function ExpenseLineCard({
+  line,
+  index,
+  accounts,
+  methods,
+  receipts,
+  canRemove,
+  onChange,
+  onRemove,
+}: {
+  line: ExpenseLine;
+  index: number;
+  accounts: LoaderData["accounts"];
+  methods: LoaderData["methods"];
+  receipts: LoaderData["receipts"];
+  canRemove: boolean;
+  onChange: (patch: Partial<ExpenseLine>) => void;
+  onRemove: () => void;
+}) {
+  // Show validation only once a line has been touched, so a fresh line isn't red.
+  const touched = line.amountInCents > 0 || line.accountId !== "" || line.vendor !== "" || line.description !== "";
+  const problems = touched ? lineProblems(line) : [];
+
+  const [amountText, setAmountText] = useState(line.amountInCents > 0 ? (line.amountInCents / 100).toString() : "");
+
+  function commitAmount(value: string) {
+    setAmountText(value);
+    const dollars = Number(value.replace(/[$,\s]/g, ""));
+    onChange({ amountInCents: Number.isFinite(dollars) && dollars > 0 ? Math.round(dollars * 100) : 0 });
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 pt-6">
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+            Expense {index + 1}
+          </span>
+          {canRemove ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onRemove}
+              aria-label={`Remove expense ${index + 1}`}
+            >
+              <IconTrash className="size-4" aria-hidden="true" />
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label="Date" htmlFor={`date-${line.key}`}>
+            <Input
+              id={`date-${line.key}`}
+              type="date"
+              value={line.date}
+              onChange={(e) => onChange({ date: e.target.value })}
+            />
+          </Field>
+          <Field label="Amount" htmlFor={`amount-${line.key}`}>
+            <Input
+              id={`amount-${line.key}`}
+              inputMode="decimal"
+              placeholder="0.00"
+              value={amountText}
+              onChange={(e) => commitAmount(e.target.value)}
+            />
+          </Field>
+        </div>
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Field label="Account" htmlFor={`account-${line.key}`}>
+            <Select value={line.accountId} onValueChange={(v) => onChange({ accountId: v })}>
+              <SelectTrigger id={`account-${line.key}`} aria-label="Account">
+                <SelectValue placeholder="Choose an account" />
+              </SelectTrigger>
+              <SelectContent>
+                {accounts.map((a) => (
+                  <SelectItem key={a.id} value={a.id}>
+                    {a.code} — {a.description}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field label="Payment method" htmlFor={`method-${line.key}`}>
+            <Select
+              value={line.methodId !== null ? String(line.methodId) : undefined}
+              onValueChange={(v) => onChange({ methodId: Number(v) })}
+            >
+              <SelectTrigger id={`method-${line.key}`} aria-label="Payment method">
+                <SelectValue placeholder="Choose a method" />
+              </SelectTrigger>
+              <SelectContent>
+                {methods.map((m) => (
+                  <SelectItem key={m.id} value={String(m.id)}>
+                    {m.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+        </div>
+
+        <Field label="Vendor" htmlFor={`vendor-${line.key}`} optional>
+          <Input
+            id={`vendor-${line.key}`}
+            value={line.vendor}
+            placeholder="Where the expense was incurred"
+            onChange={(e) => onChange({ vendor: e.target.value })}
+          />
+        </Field>
+
+        <Field label="Note" htmlFor={`note-${line.key}`} optional>
+          <Textarea
+            id={`note-${line.key}`}
+            rows={2}
+            value={line.description}
+            placeholder="What this expense was for"
+            onChange={(e) => onChange({ description: e.target.value })}
+          />
+        </Field>
+
+        <ReceiptPicker
+          receipts={receipts}
+          selected={line.receiptIds}
+          onChange={(receiptIds) => onChange({ receiptIds })}
+        />
+
+        {problems.length > 0 ? <p className="text-destructive text-xs font-medium">{problems.join(" · ")}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReceiptPicker({
+  receipts,
+  selected,
+  onChange,
+}: {
+  receipts: LoaderData["receipts"];
+  selected: Array<string>;
+  onChange: (ids: Array<string>) => void;
+}) {
+  if (receipts.length === 0) {
+    return <p className="text-muted-foreground text-xs">No uploaded receipts to attach.</p>;
+  }
+
+  function toggle(id: string) {
+    onChange(selected.includes(id) ? selected.filter((r) => r !== id) : [...selected, id]);
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" size="sm">
+          <IconPaperclip className="mr-2 size-4" aria-hidden="true" />
+          {selected.length > 0
+            ? `${selected.length} receipt${selected.length === 1 ? "" : "s"} attached`
+            : "Attach receipts"}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="max-h-72 w-80 overflow-auto">
+        <div className="space-y-1">
+          {receipts.map((r) => (
+            <Label
+              key={r.id}
+              className="hover:bg-muted flex cursor-pointer items-center gap-2 rounded p-1.5 font-normal"
+            >
+              <Checkbox checked={selected.includes(r.id)} onCheckedChange={() => toggle(r.id)} />
+              <span className="truncate text-sm">{r.title}</span>
+            </Label>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  optional,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  optional?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={htmlFor}>
+        {label}
+        {optional ? <span className="text-muted-foreground ml-1 text-xs">(optional)</span> : null}
+      </Label>
+      {children}
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  return <ErrorComponent />;
+}

--- a/app/services.server/expense-report.ts
+++ b/app/services.server/expense-report.ts
@@ -1,0 +1,76 @@
+import { ReimbursementRequestStatus } from "@prisma/client";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+import { createLogger } from "~/integrations/logger.server";
+import { db } from "~/integrations/prisma.server";
+import type { ExpenseLine } from "~/lib/expense-report";
+
+dayjs.extend(utc);
+
+const logger = createLogger("ExpenseReportService");
+
+export type ExpenseReportSummary = { created: number; totalInCents: number };
+
+export const ExpenseReportService = {
+  /**
+   * Submit an expense report as a batch of reimbursement requests — one per
+   * line — in a single database transaction, so the report is all-or-nothing.
+   *
+   * Every referenced account and receipt is re-checked against the org here
+   * rather than trusted from the client, so a tampered payload can't attach
+   * another org's receipt or bill another org's account.
+   */
+  async submit({ lines, userId, orgId }: { lines: Array<ExpenseLine>; userId: string; orgId: string }) {
+    if (lines.length === 0) {
+      throw new Error("An expense report needs at least one line.");
+    }
+
+    const accountIds = [...new Set(lines.map((l) => l.accountId))];
+    const ownedAccounts = await db.account.findMany({
+      where: { id: { in: accountIds }, orgId },
+      select: { id: true },
+    });
+    if (ownedAccounts.length !== accountIds.length) {
+      throw new Error("One or more accounts do not belong to this organization.");
+    }
+
+    const receiptIds = [...new Set(lines.flatMap((l) => l.receiptIds))];
+    if (receiptIds.length > 0) {
+      const ownedReceipts = await db.receipt.findMany({
+        where: { id: { in: receiptIds }, orgId },
+        select: { id: true },
+      });
+      if (ownedReceipts.length !== receiptIds.length) {
+        throw new Error("One or more receipts could not be found.");
+      }
+    }
+
+    const created = await db.$transaction(
+      lines.map((line) =>
+        db.reimbursementRequest.create({
+          data: {
+            orgId,
+            userId,
+            status: ReimbursementRequestStatus.PENDING,
+            date: dayjs.utc(line.date).startOf("day").toDate(),
+            vendor: line.vendor.trim() || null,
+            description: line.description.trim() || null,
+            amountInCents: line.amountInCents,
+            accountId: line.accountId,
+            methodId: line.methodId!,
+            receipts: line.receiptIds.length ? { connect: line.receiptIds.map((id) => ({ id })) } : undefined,
+          },
+          select: { id: true },
+        }),
+      ),
+    );
+
+    const summary: ExpenseReportSummary = {
+      created: created.length,
+      totalInCents: lines.reduce((total, line) => total + line.amountInCents, 0),
+    };
+    logger.info("Expense report submitted", { orgId, userId, ...summary });
+    return summary;
+  },
+};


### PR DESCRIPTION
Lets a staff member itemize several expenses into one report and submit them for reimbursement together, instead of filing a separate request per receipt.

## The flow
A new page at `/expense-reports/new`:
- Add, edit, and remove expense lines — each with date, amount, account, payment method, vendor, note, and optional receipts.
- Per-line validation appears only once a line has been touched, so a fresh blank line isn't shown as an error.
- A live **report total** plus **per-account subtotals**, since a report often draws from more than one fund and each fund's admin needs its own figure.

## What submitting does
Creates **one reimbursement request per line in a single database transaction** — all-or-nothing, so a partial report can never land. Each request then flows through the existing approval process untouched. The org gets **one summary email** for the whole report rather than one per line.

## Why reimbursement requests (not a new model)
A reimbursement request already carries everything a report line needs (date, vendor, amount, account, method, receipts), and category is assigned by the admin at approval — so there was no reason to add a schema table or change the approval side. That keeps this PR additive and small.

## Notes for review
- No schema change, no migration.
- Accounts and receipts are re-verified against the org **server-side** in the service, so a tampered client payload can't attach another org's receipt or bill another org's account.
- Report math (total, per-account subtotals, per-line validation) is pure in `app/lib/expense-report.ts` with **12 unit tests**.
- Dates written in UTC, consistent with the rest of the app.

## Verified locally
`tsc --noEmit` clean · `eslint` 0 errors · 84 unit tests pass · `react-router build` succeeds

## Test plan
- [ ] Add several lines across two accounts → subtotals and total are correct
- [ ] Submit → that many reimbursement requests appear for an admin to approve
- [ ] Leave a line incomplete → submit is disabled and the line shows what's missing
- [ ] Attach receipts to a line → they arrive on that line's request
- [ ] Confirm one summary email arrives, not one per line

🤖 Generated with [Claude Code](https://claude.com/claude-code)