### PR TITLE
PR 12: Financial summary report

### DIFF
--- a/app/lib/financial-summary.test.ts
+++ b/app/lib/financial-summary.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { summarizeFinancials, summaryToCsv, type SummarizableTransaction } from "~/lib/financial-summary";
+
+function tx(over: Partial<SummarizableTransaction> = {}): SummarizableTransaction {
+  return {
+    amountInCents: 10000,
+    accountId: "acct-1",
+    accountCode: "1001",
+    accountDescription: "General Fund",
+    categoryId: 1,
+    categoryName: "Donation: Standard",
+    ...over,
+  };
+}
+
+describe("summarizeFinancials", () => {
+  it("splits income and expense from signed amounts", () => {
+    const { totals } = summarizeFinancials([tx({ amountInCents: 10000 }), tx({ amountInCents: -4000 })]);
+    expect(totals).toEqual({ incomeInCents: 10000, expenseInCents: 4000, netInCents: 6000 });
+  });
+
+  it("totals each fund separately, ordered by code", () => {
+    const summary = summarizeFinancials([
+      tx({ accountId: "b", accountCode: "2001", accountDescription: "Local", amountInCents: 5000 }),
+      tx({ accountId: "a", accountCode: "1001", accountDescription: "General", amountInCents: 10000 }),
+      tx({ accountId: "a", accountCode: "1001", accountDescription: "General", amountInCents: -3000 }),
+    ]);
+
+    expect(summary.byFund.map((f) => f.code)).toEqual(["1001", "2001"]);
+    expect(summary.byFund[0]).toMatchObject({ incomeInCents: 10000, expenseInCents: 3000, netInCents: 7000 });
+    expect(summary.byFund[1]).toMatchObject({ incomeInCents: 5000, expenseInCents: 0, netInCents: 5000 });
+  });
+
+  it("groups by category, largest net first", () => {
+    const summary = summarizeFinancials([
+      tx({ categoryId: 1, categoryName: "Donation", amountInCents: 8000 }),
+      tx({ categoryId: 11, categoryName: "Expense: Other", amountInCents: -2000 }),
+      tx({ categoryId: 1, categoryName: "Donation", amountInCents: 2000 }),
+    ]);
+
+    expect(summary.byCategory.map((c) => c.name)).toEqual(["Donation", "Expense: Other"]);
+    expect(summary.byCategory[0]).toMatchObject({ incomeInCents: 10000, netInCents: 10000 });
+    expect(summary.byCategory[1]).toMatchObject({ expenseInCents: 2000, netInCents: -2000 });
+  });
+
+  it("buckets null categories as Uncategorized", () => {
+    const summary = summarizeFinancials([tx({ categoryId: null, categoryName: null, amountInCents: 1500 })]);
+    expect(summary.byCategory[0]).toMatchObject({ categoryId: null, name: "Uncategorized", incomeInCents: 1500 });
+  });
+
+  it("treats a zero amount as income of zero, not expense", () => {
+    const { totals } = summarizeFinancials([tx({ amountInCents: 0 })]);
+    expect(totals).toEqual({ incomeInCents: 0, expenseInCents: 0, netInCents: 0 });
+  });
+
+  it("returns empty structures for no transactions", () => {
+    expect(summarizeFinancials([])).toEqual({
+      byFund: [],
+      byCategory: [],
+      totals: { incomeInCents: 0, expenseInCents: 0, netInCents: 0 },
+    });
+  });
+});
+
+describe("summaryToCsv", () => {
+  it("renders fund, category, and totals sections with two-decimal dollars", () => {
+    const summary = summarizeFinancials([
+      tx({ amountInCents: 12345 }),
+      tx({ amountInCents: -2000, categoryId: 11, categoryName: "Expense: Other" }),
+    ]);
+    const csv = summaryToCsv(summary, { start: "2026-01-01", end: "2026-12-31" });
+
+    expect(csv).toContain("Financial Summary");
+    expect(csv).toContain("2026-01-01 to 2026-12-31");
+    expect(csv).toContain("1001,General Fund,123.45,20.00,103.45");
+    expect(csv).toContain("Totals,123.45,20.00,103.45");
+  });
+
+  it("quotes cells that contain commas", () => {
+    const summary = summarizeFinancials([tx({ accountDescription: "General, Unrestricted", amountInCents: 1000 })]);
+    const csv = summaryToCsv(summary, { start: "2026-01-01", end: "2026-12-31" });
+    expect(csv).toContain('"General, Unrestricted"');
+  });
+});

--- a/app/lib/financial-summary.ts
+++ b/app/lib/financial-summary.ts
@@ -1,0 +1,125 @@
+/**
+ * One transaction reduced to what a financial summary needs. Amounts follow the
+ * app-wide convention: positive is money in, negative is money out.
+ */
+export type SummarizableTransaction = {
+  amountInCents: number;
+  accountId: string;
+  accountCode: string;
+  accountDescription: string;
+  categoryId: number | null;
+  categoryName: string | null;
+};
+
+export type Totals = { incomeInCents: number; expenseInCents: number; netInCents: number };
+
+export type FundRow = Totals & { accountId: string; code: string; description: string };
+export type CategoryRow = Totals & { categoryId: number | null; name: string };
+
+export type FinancialSummary = {
+  byFund: Array<FundRow>;
+  byCategory: Array<CategoryRow>;
+  totals: Totals;
+};
+
+const UNCATEGORIZED = "Uncategorized";
+
+/** Split one signed amount into its income and expense magnitudes. */
+function apply(totals: Totals, amountInCents: number): void {
+  if (amountInCents >= 0) {
+    totals.incomeInCents += amountInCents;
+  } else {
+    totals.expenseInCents += -amountInCents;
+  }
+  totals.netInCents += amountInCents;
+}
+
+function emptyTotals(): Totals {
+  return { incomeInCents: 0, expenseInCents: 0, netInCents: 0 };
+}
+
+/**
+ * Summarize transactions into income/expense/net totals overall, by fund, and
+ * by category. Income is the sum of money in, expense the sum of money out (as a
+ * positive figure), and net their difference — the shape a statement of
+ * activities and a 990 both want.
+ *
+ * Funds are ordered by account code; categories by net, largest inflow first,
+ * so the biggest revenue lines sit at the top and expenses fall to the bottom.
+ */
+export function summarizeFinancials(transactions: Array<SummarizableTransaction>): FinancialSummary {
+  const totals = emptyTotals();
+  const funds = new Map<string, FundRow>();
+  const categories = new Map<string, CategoryRow>();
+
+  for (const t of transactions) {
+    apply(totals, t.amountInCents);
+
+    let fund = funds.get(t.accountId);
+    if (!fund) {
+      fund = { accountId: t.accountId, code: t.accountCode, description: t.accountDescription, ...emptyTotals() };
+      funds.set(t.accountId, fund);
+    }
+    apply(fund, t.amountInCents);
+
+    const categoryKey = t.categoryId === null ? UNCATEGORIZED : String(t.categoryId);
+    let category = categories.get(categoryKey);
+    if (!category) {
+      category = { categoryId: t.categoryId, name: t.categoryName ?? UNCATEGORIZED, ...emptyTotals() };
+      categories.set(categoryKey, category);
+    }
+    apply(category, t.amountInCents);
+  }
+
+  return {
+    byFund: [...funds.values()].sort((a, b) => a.code.localeCompare(b.code)),
+    byCategory: [...categories.values()].sort((a, b) => b.netInCents - a.netInCents),
+    totals,
+  };
+}
+
+/** A cell value quoted for CSV only when it contains a comma, quote, or newline. */
+function csvCell(value: string | number): string {
+  const s = String(value);
+  return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function dollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+/**
+ * Render the summary as CSV: a fund section, a category section, and a totals
+ * line, with dollars to two decimals. Built from the same summary the page
+ * shows, so the download and the screen never disagree.
+ */
+export function summaryToCsv(summary: FinancialSummary, range: { start: string; end: string }): string {
+  const rows: Array<Array<string | number>> = [];
+
+  rows.push(["Financial Summary"]);
+  rows.push(["Period", `${range.start} to ${range.end}`]);
+  rows.push([]);
+
+  rows.push(["By Fund"]);
+  rows.push(["Code", "Fund", "Income", "Expense", "Net"]);
+  for (const f of summary.byFund) {
+    rows.push([f.code, f.description, dollars(f.incomeInCents), dollars(f.expenseInCents), dollars(f.netInCents)]);
+  }
+  rows.push([]);
+
+  rows.push(["By Category"]);
+  rows.push(["Category", "Income", "Expense", "Net"]);
+  for (const c of summary.byCategory) {
+    rows.push([c.name, dollars(c.incomeInCents), dollars(c.expenseInCents), dollars(c.netInCents)]);
+  }
+  rows.push([]);
+
+  rows.push([
+    "Totals",
+    dollars(summary.totals.incomeInCents),
+    dollars(summary.totals.expenseInCents),
+    dollars(summary.totals.netInCents),
+  ]);
+
+  return rows.map((row) => row.map(csvCell).join(",")).join("\n");
+}

--- a/app/routes/_app.reports._index.tsx
+++ b/app/routes/_app.reports._index.tsx
@@ -33,6 +33,18 @@ export default function AdminReports() {
       <PageHeader title="Reports" />
       <p className="text-muted-foreground mt-2 text-sm">Generate reports for your organization.</p>
       <PageContainer>
+        <div className="mb-8 max-w-md rounded-lg border p-4">
+          <h2 className="font-bold">Financial Summary</h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Income and expenses totaled by fund and category over any date range, with a CSV export for 990 prep.
+          </p>
+          <Button variant="outline" asChild className="mt-3">
+            <Link to="/reports/financial" prefetch="intent">
+              Open financial summary
+            </Link>
+          </Button>
+        </div>
+
         <h2 className="mb-2 font-bold">Transactions Report</h2>
         <div className="max-w-xs space-y-2">
           <div className="space-y-1">

--- a/app/routes/_app.reports.financial.tsx
+++ b/app/routes/_app.reports.financial.tsx
@@ -1,0 +1,233 @@
+import { IconCloudDownload } from "@tabler/icons-react";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { Form, Link, useLoaderData, useSearchParams, type LoaderFunctionArgs } from "react-router";
+
+import { PageHeader } from "~/components/common/page-header";
+import { ErrorComponent } from "~/components/error-component";
+import { PageContainer } from "~/components/page-container";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import { Label } from "~/components/ui/label";
+import { Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "~/components/ui/table";
+import { db } from "~/integrations/prisma.server";
+import { summarizeFinancials, summaryToCsv, type FinancialSummary } from "~/lib/financial-summary";
+import { handleLoaderError } from "~/lib/responses.server";
+import { cn, formatCentsAsDollars } from "~/lib/utils";
+import { SessionService } from "~/services.server/session";
+
+dayjs.extend(utc);
+
+function defaultRange() {
+  // Year to date suits 990 prep; the user can widen or narrow it.
+  return { start: dayjs().startOf("year").format("YYYY-MM-DD"), end: dayjs().format("YYYY-MM-DD") };
+}
+
+export async function loader(args: LoaderFunctionArgs) {
+  await SessionService.requireAdmin(args);
+  const orgId = await SessionService.requireOrgId(args);
+
+  const url = new URL(args.request.url);
+  const fallback = defaultRange();
+  // Treat a blank param as absent so it falls back to the default range.
+  const param = (name: string) => {
+    const value = url.searchParams.get(name);
+    return value && value.trim() !== "" ? value : null;
+  };
+  const start = param("start") ?? fallback.start;
+  const end = param("end") ?? fallback.end;
+
+  try {
+    // UTC bounds, matching how transaction dates are stored.
+    const gte = dayjs.utc(start).startOf("day").toDate();
+    const lte = dayjs.utc(end).endOf("day").toDate();
+
+    const transactions = await db.transaction.findMany({
+      where: { orgId, voidedAt: null, date: { gte, lte } },
+      select: {
+        amountInCents: true,
+        accountId: true,
+        account: { select: { code: true, description: true } },
+        categoryId: true,
+        category: { select: { name: true } },
+      },
+    });
+
+    const summary = summarizeFinancials(
+      transactions.map((t) => ({
+        amountInCents: t.amountInCents,
+        accountId: t.accountId,
+        accountCode: t.account.code,
+        accountDescription: t.account.description,
+        categoryId: t.categoryId,
+        categoryName: t.category?.name ?? null,
+      })),
+    );
+
+    if (url.searchParams.get("format") === "csv") {
+      const org = await db.organization.findUnique({ where: { id: orgId }, select: { name: true } });
+      const filename = `${org?.name ?? "causeway"}-financial-summary-${start}-to-${end}.csv`;
+      return new Response(summaryToCsv(summary, { start, end }), {
+        headers: {
+          "Content-Type": "text/csv; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${filename.replace(/[^\w.\- ]/g, "")}"`,
+        },
+      });
+    }
+
+    return { summary, start, end, transactionCount: transactions.length };
+  } catch (e) {
+    handleLoaderError(e);
+  }
+}
+
+export default function FinancialReportPage() {
+  const { summary, start, end, transactionCount } = useLoaderData<typeof loader>();
+  const [searchParams] = useSearchParams();
+
+  const csvHref = `/reports/financial?${new URLSearchParams({ start, end, format: "csv" }).toString()}`;
+
+  return (
+    <>
+      <title>Financial Summary</title>
+      <PageHeader title="Financial Summary" description="Income and expenses by fund and category over a date range." />
+      <PageContainer className="max-w-4xl">
+        <Form method="get" className="mb-6 flex flex-wrap items-end gap-3">
+          <div className="space-y-1">
+            <Label htmlFor="start">Start date</Label>
+            <Input id="start" name="start" type="date" defaultValue={searchParams.get("start") ?? start} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="end">End date</Label>
+            <Input id="end" name="end" type="date" defaultValue={searchParams.get("end") ?? end} />
+          </div>
+          <Button type="submit" variant="outline">
+            Update
+          </Button>
+          <Button asChild className="ml-auto">
+            <Link reloadDocument to={csvHref}>
+              <IconCloudDownload className="mr-2 size-4" aria-hidden="true" />
+              Download CSV
+            </Link>
+          </Button>
+        </Form>
+
+        <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <Figure label="Income" value={formatCentsAsDollars(summary.totals.incomeInCents)} emphasis="good" />
+          <Figure label="Expenses" value={formatCentsAsDollars(summary.totals.expenseInCents)} />
+          <Figure
+            label="Net"
+            value={formatCentsAsDollars(summary.totals.netInCents)}
+            emphasis={summary.totals.netInCents >= 0 ? "good" : "warning"}
+          />
+        </div>
+
+        {transactionCount === 0 ? (
+          <p className="text-muted-foreground rounded-lg border border-dashed p-8 text-center text-sm">
+            No transactions between {dayjs.utc(start).format("MMM D, YYYY")} and {dayjs.utc(end).format("MMM D, YYYY")}.
+          </p>
+        ) : (
+          <div className="space-y-8">
+            <SummaryTable
+              caption="By fund"
+              firstHeader="Fund"
+              rows={summary.byFund.map((f) => ({
+                key: f.accountId,
+                label: `${f.code} — ${f.description}`,
+                ...f,
+              }))}
+              totals={summary.totals}
+            />
+            <SummaryTable
+              caption="By category"
+              firstHeader="Category"
+              rows={summary.byCategory.map((c) => ({
+                key: c.categoryId === null ? "none" : String(c.categoryId),
+                label: c.name,
+                ...c,
+              }))}
+              totals={summary.totals}
+            />
+          </div>
+        )}
+      </PageContainer>
+    </>
+  );
+}
+
+function SummaryTable({
+  caption,
+  firstHeader,
+  rows,
+  totals,
+}: {
+  caption: string;
+  firstHeader: string;
+  rows: Array<{ key: string; label: string; incomeInCents: number; expenseInCents: number; netInCents: number }>;
+  totals: FinancialSummary["totals"];
+}) {
+  return (
+    <div>
+      <h2 className="mb-2 text-sm font-medium">{caption}</h2>
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{firstHeader}</TableHead>
+              <TableHead className="text-right">Income</TableHead>
+              <TableHead className="text-right">Expense</TableHead>
+              <TableHead className="text-right">Net</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.key}>
+                <TableCell className="max-w-[280px] truncate">{row.label}</TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {row.incomeInCents ? formatCentsAsDollars(row.incomeInCents) : "—"}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {row.expenseInCents ? formatCentsAsDollars(row.expenseInCents) : "—"}
+                </TableCell>
+                <TableCell className={cn("text-right font-medium tabular-nums", row.netInCents < 0 && "text-warning")}>
+                  {formatCentsAsDollars(row.netInCents)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TableCell className="font-medium">Total</TableCell>
+              <TableCell className="text-right tabular-nums">{formatCentsAsDollars(totals.incomeInCents)}</TableCell>
+              <TableCell className="text-right tabular-nums">{formatCentsAsDollars(totals.expenseInCents)}</TableCell>
+              <TableCell className="text-right font-medium tabular-nums">
+                {formatCentsAsDollars(totals.netInCents)}
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+function Figure({ label, value, emphasis }: { label: string; value: string; emphasis?: "good" | "warning" }) {
+  return (
+    <div className="rounded-md border p-3">
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <p
+        className={cn(
+          "text-lg font-semibold tabular-nums",
+          emphasis === "good" && "text-success",
+          emphasis === "warning" && "text-warning",
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+export function ErrorBoundary() {
+  return <ErrorComponent />;
+}


### PR DESCRIPTION
Adds a financial summary at `/reports/financial` — income, expenses, and net over a date range, broken down by fund and by category. This is the statement-of-activities view your 990 prep needs; the existing export only produces a raw transaction dump.

## The page
- **Date range filter**, defaulting to year-to-date.
- **Totals cards** (income / expenses / net) up top.
- **By fund** table and **By category** table, each with a footer total.
- **Download CSV** built from the exact same summary the page renders, so the file and the screen can never disagree.
- Linked from the existing reports index.

## How income vs expense is derived
Straight from the sign convention already used everywhere: positive amounts are income, negative are expense (shown as a positive figure), and net is their difference. No new classification rules to get out of sync with the rest of the app.

## Notes for review
- No schema change.
- Voided transactions are excluded and date bounds are UTC, consistent with PRs 2, 7, 8, 9.
- Aggregation and CSV rendering are pure in `app/lib/financial-summary.ts` with **8 unit tests**, including the total-of-totals footer, null-category bucketing, and CSV quoting of values containing commas.
- The CSV filename is stripped of anything but word characters, spaces, dots, and dashes before going into the `Content-Disposition` header.

## Verified locally
`tsc --noEmit` clean · `eslint` 0 errors · 107 unit tests pass · `react-router build` succeeds

## Test plan
- [ ] Open the financial summary → year-to-date totals look right
- [ ] Change the date range and Update → tables and totals recompute
- [ ] By-fund and by-category totals both reconcile to the same grand total
- [ ] Download CSV → opens in a spreadsheet with matching numbers
- [ ] A fund whose description contains a comma stays in one CSV column

🤖 Generated with [Claude Code](https://claude.com/claude-code)