### PR TITLE
PR 13: Dashboard summary, voided-transaction badges, quick links

### DIFF
--- a/app/lib/financial-summary.test.ts
+++ b/app/lib/financial-summary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { summarizeFinancials, summaryToCsv, type SummarizableTransaction } from "~/lib/financial-summary";
+import { summarizeFinancials, summaryToCsv, sumTotals, type SummarizableTransaction } from "~/lib/financial-summary";
 
 function tx(over: Partial<SummarizableTransaction> = {}): SummarizableTransaction {
   return {
@@ -60,6 +60,20 @@ describe("summarizeFinancials", () => {
       byCategory: [],
       totals: { incomeInCents: 0, expenseInCents: 0, netInCents: 0 },
     });
+  });
+});
+
+describe("sumTotals", () => {
+  it("splits a list of signed amounts into income, expense, and net", () => {
+    expect(sumTotals([10000, -4000, 2500])).toEqual({
+      incomeInCents: 12500,
+      expenseInCents: 4000,
+      netInCents: 8500,
+    });
+  });
+
+  it("is all zeros for an empty list", () => {
+    expect(sumTotals([])).toEqual({ incomeInCents: 0, expenseInCents: 0, netInCents: 0 });
   });
 });
 

--- a/app/lib/financial-summary.ts
+++ b/app/lib/financial-summary.ts
@@ -39,6 +39,17 @@ function emptyTotals(): Totals {
 }
 
 /**
+ * Income/expense/net for a bare list of signed amounts. The same split the full
+ * summary uses, for callers (like the dashboard) that only need the headline
+ * numbers and don't want to load account and category detail.
+ */
+export function sumTotals(amountsInCents: Array<number>): Totals {
+  const totals = emptyTotals();
+  for (const amount of amountsInCents) apply(totals, amount);
+  return totals;
+}
+
+/**
  * Summarize transactions into income/expense/net totals overall, by fund, and
  * by category. Income is the sum of money in, expense the sum of money out (as a
  * positive figure), and net their difference — the shape a statement of

--- a/app/routes/_app.dashboards.admin._index.tsx
+++ b/app/routes/_app.dashboards.admin._index.tsx
@@ -16,7 +16,9 @@ import { Callout } from "~/components/ui/callout";
 import { AccountBalanceCard } from "~/components/users/balance-card";
 import { db } from "~/integrations/prisma.server";
 import { AccountType } from "~/lib/constants";
+import { sumTotals } from "~/lib/financial-summary";
 import { handleLoaderError } from "~/lib/responses.server";
+import { cn, formatCentsAsDollars } from "~/lib/utils";
 import { SessionService } from "~/services.server/session";
 
 export async function loader(args: LoaderFunctionArgs) {
@@ -28,7 +30,7 @@ export async function loader(args: LoaderFunctionArgs) {
       return redirect("/dashboards/staff");
     }
 
-    const [accounts, reimbursementRequests, announcement, missingEmailCount] = await db.$transaction([
+    const [accounts, reimbursementRequests, announcement, missingEmailCount, ytdTransactions] = await db.$transaction([
       db.account.findMany({
         select: {
           id: true,
@@ -87,17 +89,28 @@ export async function loader(args: LoaderFunctionArgs) {
         orderBy: { id: "desc" },
       }),
       db.contact.count({ where: { orgId, email: null } }),
+      // Year-to-date activity for the headline income/expense/net tiles.
+      db.transaction.findMany({
+        where: { orgId, voidedAt: null, date: { gte: dayjs().utc().startOf("year").toDate() } },
+        select: { amountInCents: true },
+      }),
     ]);
 
-    return { accounts, reimbursementRequests, announcement, missingEmailCount };
+    const ytd = sumTotals(ytdTransactions.map((t) => t.amountInCents));
+    const pendingTotalInCents = reimbursementRequests.reduce((sum, r) => sum + r.amountInCents, 0);
+
+    return { accounts, reimbursementRequests, announcement, missingEmailCount, ytd, pendingTotalInCents };
   } catch (e) {
     handleLoaderError(e);
   }
 }
 
 export default function Index() {
-  const { accounts, reimbursementRequests, announcement, missingEmailCount } = useLoaderData<typeof loader>();
+  const { accounts, reimbursementRequests, announcement, missingEmailCount, ytd, pendingTotalInCents } =
+    useLoaderData<typeof loader>();
   const [healthDismissed, setHealthDismissed] = useState(false);
+
+  const currentYear = dayjs().year();
 
   return (
     <>
@@ -128,6 +141,41 @@ export default function Index() {
         <div className="mb-4">
           {announcement ? <AnnouncementCard announcement={announcement} /> : <AnnouncementModal intent="create" />}
         </div>
+
+        <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label={`Income (${currentYear})`} value={formatCentsAsDollars(ytd.incomeInCents)} tone="good" />
+          <Stat label={`Expenses (${currentYear})`} value={formatCentsAsDollars(ytd.expenseInCents)} />
+          <Stat
+            label={`Net (${currentYear})`}
+            value={formatCentsAsDollars(ytd.netInCents)}
+            tone={ytd.netInCents >= 0 ? "good" : "warning"}
+          />
+          <Stat
+            label="Pending reimbursements"
+            value={formatCentsAsDollars(pendingTotalInCents)}
+            sublabel={`${reimbursementRequests.length} request${reimbursementRequests.length === 1 ? "" : "s"}`}
+            tone={reimbursementRequests.length > 0 ? "warning" : undefined}
+          />
+        </div>
+
+        <div className="mb-6 flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/reports/financial" prefetch="intent">
+              Financial summary
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/reconciliations" prefetch="intent">
+              Reconcile
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/transactions/import" prefetch="intent">
+              Import donations
+            </Link>
+          </Button>
+        </div>
+
         <div className="space-y-4">
           <div className="grid auto-rows-fr grid-cols-1 gap-4 lg:grid-cols-2">
             {accounts.map((a) => {
@@ -143,6 +191,34 @@ export default function Index() {
         </div>
       </PageContainer>
     </>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  sublabel,
+  tone,
+}: {
+  label: string;
+  value: string;
+  sublabel?: string;
+  tone?: "good" | "warning";
+}) {
+  return (
+    <div className="rounded-lg border p-3">
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <p
+        className={cn(
+          "text-lg font-semibold tabular-nums",
+          tone === "good" && "text-success",
+          tone === "warning" && "text-warning",
+        )}
+      >
+        {value}
+      </p>
+      {sublabel ? <p className="text-muted-foreground text-xs">{sublabel}</p> : null}
+    </div>
   );
 }
 

--- a/app/routes/_app.transactions._index.tsx
+++ b/app/routes/_app.transactions._index.tsx
@@ -10,11 +10,12 @@ import { PageHeader } from "~/components/common/page-header";
 import { ErrorComponent } from "~/components/error-component";
 import { PageContainer } from "~/components/page-container";
 import { TransactionSearch } from "~/components/transactions/transaction-search";
+import { Badge } from "~/components/ui/badge";
 import { DataTable, DEFAULT_PAGE_SIZE } from "~/components/ui/data-table/data-table";
 import { DataTableColumnHeader } from "~/components/ui/data-table/data-table-column-header";
 import { Facet } from "~/components/ui/data-table/data-table-toolbar";
 import { db } from "~/integrations/prisma.server";
-import { formatCentsAsDollars } from "~/lib/utils";
+import { cn, formatCentsAsDollars } from "~/lib/utils";
 import { SessionService } from "~/services.server/session";
 
 export async function loader(args: LoaderFunctionArgs) {
@@ -64,6 +65,7 @@ export async function loader(args: LoaderFunctionArgs) {
         date: true,
         amountInCents: true,
         description: true,
+        voidedAt: true,
         category: true,
         contact: {
           select: {
@@ -152,9 +154,22 @@ const columns = [
     accessorFn: (row) => formatCentsAsDollars(row.amountInCents, 2),
     header: ({ column }) => <DataTableColumnHeader column={column} title="Amount" />,
     cell: ({ row }) => {
+      const isVoided = row.original.voidedAt !== null;
       return (
-        <div className="max-w-[100px]">
-          <span className="sentry-mask truncate font-medium tabular-nums">{row.getValue("amountInCents")}</span>
+        <div className="flex max-w-[160px] items-center gap-2">
+          <span
+            className={cn(
+              "sentry-mask truncate font-medium tabular-nums",
+              isVoided && "text-muted-foreground line-through",
+            )}
+          >
+            {row.getValue("amountInCents")}
+          </span>
+          {isVoided ? (
+            <Badge variant="outline" className="shrink-0 text-xs">
+              Voided
+            </Badge>
+          ) : null}
         </div>
       );
     },


### PR DESCRIPTION
The final PR in the roadmap — dashboard and transaction-list polish that surfaces everything built across PRs 1–12.

## Admin dashboard
- **Year-to-date tiles**: income, expenses, net, and a pending-reimbursements total (amount + count). The YTD figures reuse the financial summary's `sumTotals`, so the dashboard and the report page agree by construction rather than by coincidence.
- **Quick links** to the financial summary, reconciliation, and donation import, so the new tools are one click from the home screen.

## Transaction list
- Voided transactions now show a **"Voided" badge** with the amount struck through. Since PR 2 they've been excluded from balances but still listed with no marker, so the ledger and the balances looked like they disagreed — the badge closes that gap without hiding the row from the audit trail.

## Notes for review
- No schema change.
- `sumTotals` is pure and unit tested (2 new tests); the voided badge reads the `voidedAt` already on the model.
- YTD query excludes voided transactions and uses a UTC year start, consistent with the rest of the app.

## Verified locally
`tsc --noEmit` clean · `eslint` 0 errors · 109 unit tests pass · `react-router build` succeeds

## Test plan
- [ ] Dashboard shows YTD income/expense/net and pending-reimbursement totals
- [ ] Dashboard net matches the financial summary for a year-to-date range
- [ ] Quick links reach the financial summary, reconciliation, and import pages
- [ ] A voided transaction shows the badge and struck-through amount in the list
- [ ] The account balance still excludes that voided transaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)