### PR TITLE
Run PR checks against the PR, not the base branch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,17 +1,21 @@
-name: Vercel Preview Deployment
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+name: PR
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - staging
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  lint:
-    name: ✨ Lint
+  ci:
+    name: ✅ CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -22,44 +26,6 @@ jobs:
       - run: npm ci
       - run: npm run typegen
       - run: npm run lint
-
-  test:
-    name: 🧪 Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.19.0
-          cache: "npm"
-      - run: npm ci
-      - run: npm run test
-
-  typecheck:
-    name: 🧠 Typecheck
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24.19.0
-          cache: "npm"
-      - run: npm ci
-      - run: npm run typegen
       - run: npm run typecheck
-
-  build:
-    name: 🛠️ Build
-    environment: preview
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install Vercel CLI
-        run: npm install --global vercel@latest
-
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - run: npm run test
+      - run: npm run build


### PR DESCRIPTION
## The bug

`pr.yml` triggered on `pull_request_target` with a bare `actions/checkout`. That combination checks out the **base branch**, not the pull request. From the Typecheck job log on a recent PR:

```
git checkout --progress --force -B main refs/remotes/origin/main
```

So Lint, Test, and Typecheck have been running against `main` on every PR and passing regardless of the PR's contents. A branch with 26 typecheck errors reported a green ✅ Typecheck.

## Changes

- **`pull_request_target` → `pull_request`** so checkout resolves to the PR merge ref. Also drops the elevated token and secret access these checks never needed.
- **`vercel pull`/`vercel build` → `npm run build`.** Same `react-router build` that `vercel build` wraps, verified to exit 0 with no environment variables at all. No token needed, so the job works unchanged for forks and Dependabot.
- **Removed `environment: preview`.** With no secrets left to scope, it served no purpose — and it was failing PRs into `main`, since the `preview` environment's branch policy only permits `staging`. Deployment stays in `preview.yml`/`production.yml`, where environment gates belong.
- **Four jobs → one**, so `npm ci` runs once instead of four times.
- **Added `concurrency`** so force-pushes cancel superseded runs, and **`permissions: contents: read`**.

## Verification

Full sequence run locally against `main`: typegen, lint, typecheck, 40/40 tests, and build all pass. Build confirmed to succeed under `env -i`.

## Note

Worth merging before the open PR stack — those PRs have not actually been tested yet.